### PR TITLE
Alert when no data to save.

### DIFF
--- a/apps/segment/segment.js
+++ b/apps/segment/segment.js
@@ -1045,6 +1045,7 @@ function watershed(inn, out, save=null, thresh) {
   }
   console.log(segcount);
   console.log("Done Drawing Contours");
+  window.segcnt = segcount  // Will be used later in downloadCSV function 
 
   // Update the count
   let clabel = document.getElementById('segcount');
@@ -1292,6 +1293,11 @@ function download(canvas, filename) {
 
 // Build a csv of the polygons and associated metadata
 function buildAndDownloadCSV(contours,fname) {
+  if(segcnt === 0)
+  {
+    alert("Nothing to download");
+    return;
+  }
   let data = '';
   let tmp = new cv.Mat();
   const self = $UI.segmentPanel;


### PR DESCRIPTION
When the object count is zero in segmentation app and we click on download CSV we get a CSV file like 

![Screenshot (133)](https://user-images.githubusercontent.com/29978031/77569928-f92e7800-6ef0-11ea-8e5c-a9abf6c36886.png)

i.e we get a blank CSV file. 
To avoid this. I added an JavaScript alert call immediately returned from the function downloadCSV without saving it.

Alert box

![Screenshot (132)](https://user-images.githubusercontent.com/29978031/77569861-e3b94e00-6ef0-11ea-8862-a0a8cd2c678e.png)


