### PR TITLE
Prevent popuppanel overflow

### DIFF
--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -1076,6 +1076,7 @@ function saveLabelAnnotCallback() {
   $UI.layersViewer.update();
   //$CAMIC.status = null;
 }
+
 function anno_callback(data) {
   // is form ok?
   const noteData = $UI.annotOptPanel._form_.value;
@@ -1100,6 +1101,16 @@ function anno_callback(data) {
     alert("No Markup On Annotation.");
     return;
   }
+
+  //Add new lines to notes to prevent overflow
+  str = noteData.notes;
+  var result_string = '';
+  while (str.length > 0) {
+    result_string += str.substring(0, 36) + '\n';
+    str = str.substring(36);
+  }
+  noteData.notes = result_string;
+
   // save
   // provenance
   Loading.open($UI.annotOptPanel.elt, "Saving Annotation...");


### PR DESCRIPTION
The notes oerflows and gos out of the popuppanel. This will prevent it from overflow. I have inserted new lines when they go out of popuppanel.
This  used to happen 
![Screenshot from 2020-03-29 05-34-16](https://user-images.githubusercontent.com/29784549/77837047-16c64080-7182-11ea-8de9-2fa9d82ebc5a.png)

Now it will not go out of the popuppanel
![Screenshot from 2020-03-29 05-32-24](https://user-images.githubusercontent.com/29784549/77837041-0746f780-7182-11ea-9180-84a754d2e560.png)
