### PR TITLE
prevent default for shortkeys

### DIFF
--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -367,8 +367,6 @@ const $D = {
 
 window.addEventListener("keydown", e => {
 
-  e.preventDefault();
-
   if (!$CAMIC || !$CAMIC.viewer) return;
   const keyCode = e.keyCode;
   // escape key to close all operations
@@ -394,6 +392,7 @@ window.addEventListener("keydown", e => {
   }
   // open measurement (ctrl + r)
   if (e.ctrlKey && keyCode == 82 && $CAMIC.viewer.measureInstance) {
+    e.preventDefault();
     const li = $UI.toolbar.getSubTool("measurement");
     const chk = li.querySelector("input[type=checkbox]");
     chk.checked = !chk.checked;
@@ -402,6 +401,7 @@ window.addEventListener("keydown", e => {
   }
   // open side-by-side (ctrl + s)
   if (e.ctrlKey && keyCode == 83) {
+    e.preventDefault();
     const li = $UI.toolbar.getSubTool("sbsviewer");
     const chk = li.querySelector("input[type=checkbox]");
     chk.checked = !chk.checked;

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -366,6 +366,9 @@ const $D = {
 };
 
 window.addEventListener("keydown", e => {
+
+  e.preventDefault();
+
   if (!$CAMIC || !$CAMIC.viewer) return;
   const keyCode = e.keyCode;
   // escape key to close all operations

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ Toolbar Shorcuts
 |------------- |-----------|
 | Annotation   |  Ctrl + a |
 | Magnifier    |  Ctrl + m |
-| Side-by-Side |  Ctrl + r |
+| Measurement    |  Ctrl + r |
+| Side-by-Side |  Ctrl + s |
 | Close all tools |  ESC   |
 
 


### PR DESCRIPTION
The shortkeys work fine for nanoborb. But for the browsers it doesn't work. The browser shortcut keys overrides our shortcuts. 

e.g. ctrl + r is for refresh in chrome. So Instead of measurement the page refreshes.

