### PR TITLE
Validation for existing slide name

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -303,7 +303,7 @@
 				
 				//Adding names to later validate for new slide names
 				existing_slide_names = data.map(d => d[1]);
-				console.log(existing_slide_names);
+				
 				const thead = HeadMapping.map(d => "<th>" + d.title + `<img id='sort1${d.title}' class='float-right sort-btn' width='10px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVRIie3XsQrCMBSF4T+CoJsddHAo9HH6AD634NbNqTgo6FI6WQdTtJLQpG0CxXsglIRyv0ugCYWZRsUGd8ARKIA0FroFTkCjxxnIYqNRcBsaFO9Dg+Cu6KS4LzoJrnh/Mr5oOwpgaSu+GNqVY6wHTN/Jo4DNz1oJrAzv7oH6a/4Ani7duabCvLVrnyKht1pggQUWWOA/g0vD2o3ulRgkOXDhcx1egYNvkTG/IIl+3nUD88gLIHVaGvUECUcAAAAASUVORK5CYII='/>
 
 				<img id='sort2${d.title}' class='float-right sort-btn' width='10px' src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAs0lEQVRIie3VsQrCMBSF4T/qoFsddBR8Hncf24KTUAquDg4ugoPWwRbSEk2aJhHlHsiQhPCdZAl8KeMBZ+fADLgF6mLNBjgBVT3OwDYFXGqojqvY8NUAV7ye3Tmj8L0EFlhggQX+F3hi2VdAZlgzJQOm2vwCPDx7kWP+Al1G0SnSyqenVsDdt3Ed7xsvgD39b3sE1kMa++BB0L54UNQVj4La8KjoOzwJ2mQJ7IADsEqF/nae93FcRiryrh8AAAAASUVORK5CYII="/>

--- a/apps/table.html
+++ b/apps/table.html
@@ -22,12 +22,19 @@
 	<script src="./loader/loader.js"></script>
 	<script src="./loader/chunked_upload.js"></script>
 	<script>
+		var existing_slide_names = [];
 		function validateForm(callback) {
 			let x = document.getElementById("slidenameRow")
 			for (var i = 0; i < x.cells.length - 1; i++) {
 				var slide = document.getElementById("slidename" + i)
 				if (slide.value === "") {
 					changeStatus("UPLOAD", "Please enter slide name");
+					return false;
+				}
+
+				//Checking if silde with given name already exists
+				if(existing_slide_names.includes(slide.value)) {
+					changeStatus("UPLOAD", "Slide with given name already exists");
 					return false;
 				}
 			}
@@ -259,7 +266,7 @@
 						return AND.call(this, v1, v2, eq);
 					});
 				}
-
+				
 				// mapping data
 				const keys = HeadMapping.map(d => d.field);
 				if (data.map) {
@@ -293,7 +300,10 @@
 					div.classList = `text-center p-4`;
 					return;
 				}
-
+				
+				//Adding names to later validate for new slide names
+				existing_slide_names = data.map(d => d[1]);
+				console.log(existing_slide_names);
 				const thead = HeadMapping.map(d => "<th>" + d.title + `<img id='sort1${d.title}' class='float-right sort-btn' width='10px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVRIie3XsQrCMBSF4T+CoJsddHAo9HH6AD634NbNqTgo6FI6WQdTtJLQpG0CxXsglIRyv0ugCYWZRsUGd8ARKIA0FroFTkCjxxnIYqNRcBsaFO9Dg+Cu6KS4LzoJrnh/Mr5oOwpgaSu+GNqVY6wHTN/Jo4DNz1oJrAzv7oH6a/4Ani7duabCvLVrnyKht1pggQUWWOA/g0vD2o3ulRgkOXDhcx1egYNvkTG/IIl+3nUD88gLIHVaGvUECUcAAAAASUVORK5CYII='/>
 
 				<img id='sort2${d.title}' class='float-right sort-btn' width='10px' src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAs0lEQVRIie3VsQrCMBSF4T/qoFsddBR8Hncf24KTUAquDg4ugoPWwRbSEk2aJhHlHsiQhPCdZAl8KeMBZ+fADLgF6mLNBjgBVT3OwDYFXGqojqvY8NUAV7ye3Tmj8L0EFlhggQX+F3hi2VdAZlgzJQOm2vwCPDx7kWP+Al1G0SnSyqenVsDdt3Ed7xsvgD39b3sE1kMa++BB0L54UNQVj4La8KjoOzwJ2mQJ7IADsEqF/nae93FcRiryrh8AAAAASUVORK5CYII="/>


### PR DESCRIPTION
While uploading new slide users are not notified if slide name is already taken. And multiple copies of same name exists. Due to this it creates bad user experience because 
later users will not know what work they have done in which slide by looking at name.

Multiple slides with same name
![Screenshot from 2020-03-29 11-38-55](https://user-images.githubusercontent.com/29784549/77842713-3c1f7280-71b3-11ea-8c93-16f7b20c60c0.png)

Now it will be validated just like empty slide name.
![Screenshot from 2020-03-29 11-38-14](https://user-images.githubusercontent.com/29784549/77842717-4d687f00-71b3-11ea-9160-db7477301d27.png)

