### PR TITLE
Allow empty note when saving annotation

### DIFF
--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -1112,7 +1112,7 @@ function anno_callback(data) {
   // Add new lines to notes to prevent overflow
   str = noteData.notes;
   var result_string = '';
-  while (str.length > 0) {
+  while (typeof str==='string' && str.length > 0) {
     result_string += str.substring(0, 36) + '\n';
     str = str.substring(36);
   }


### PR DESCRIPTION
Fixes [Issue-109](https://github.com/camicroscope/Distro/issues/109) of Distro repository.
Earlier on saving annotation with empty note, the following error was shown in the browser console -

```
draw-overlay:stop-drawing error:
stopDrawing @ openseadragon-canvas-draw-overlay.js:653
openseadragon-canvas-draw-overlay.js:654 TypeError: Cannot read property 'length' of undefined
    at anno_callback (uicallbacks.js:1115)
    at saveAnnotation (uicallbacks.js:1594)
    at Object.stopDrawing [as handler] (uicallbacks.js:1642)
    at eventsource.js:162
    at $.CanvasDraw.raiseEvent (eventsource.js:184)
    at $.CanvasDraw.stopDrawing (openseadragon-canvas-draw-overlay.js:650)
stopDrawing @ openseadragon-canvas-draw-overlay.js:654
uicallbacks.js:1115 Uncaught TypeError: Cannot read property 'length' of undefined
    at anno_callback (uicallbacks.js:1115)
    at OperationPanel.<anonymous> (operationpanel.js:202)
```