### PR TITLE
Added icons for tools to README.md [User guide enhancement]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,19 @@ The toolbar is in the top-left of the main content window. Use the toolbar butto
 
 | Tool  | Name        | Function  |
 | ----- |-------------| -----|
-|       | Annotations | Opens the Annotation panel, where you can select which annotation set to view, name that annotation set, add optional notes about the annotation set, save the annotation set, and reset the panel to its original state. |
-|       | Layer Manager      | Opens the Layers Manager panel, where you can select which layers to view. |
-|       | Home      | Return to the data table so that you can open another slide.|
-|       | Draw      |	Draw thin lines, thick lines, or polygons on the image. To maintain the integrity of measurements, avoid drawing shapes that overlap or intersect one another. |
-|       | Magnifier      |The Magnifier works like a magnifying glass and allows you to see the slide at normal magnification (1.0), low magnification (0.5), or high magnification (2.0). Click a magnification level and place the bounding box on the area of the slide you want to magnify. |
-|       | Measurement      | Drag this tool on the slide to learn the measurement in micrometers. |
-|       | Share View      |Opens a window with a URL to the current presentation state of the slide including the magnification level, layers that are currently open, and your position on the image.|
-|       | Side by Side Viewer     |Shows the Layer Manager panel, the left and right layers, and inset window. For the right and left layer, select which layer you want to view. |
-|       | Heatmap     |	For a slide with heatmap data, opens the choices of heatmaps available, as well as ways of displaying the heatmaps. The gradient shows all of the values on the selected spectrum for the field you selected. Contains a heatmap edit pen function.|
-|       | Labeling      |Use this tool to draw a circle or rectangle around a tumor region, measure an area on the slide, download labels, and submit a bug report. The Labeling tool has its own toolbar with tools in the following order from left to right: return to the previous slide, place a square on the slide, place a circle on the slide, measure an area, download labels, and submit a bug report. Click the left arrow at the far right of the toolbar to hide it, then click the right arrow to show it. |
-|       | Segment      | This tool allows you to display, count, and export nuclear segmentations on the image. Clicking this tool opens the following custom toolbar. |
-|       | Model      | Show results from a pre-trained tensorflow compatible model on a ROI of the slide. |
-|       | Bug Report      | Report a bug or give feedback. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/apps/v4/24px.svg)      | Annotations | Opens the Annotation panel, where you can select which annotation set to view, name that annotation set, add optional notes about the annotation set, save the annotation set, and reset the panel to its original state. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/view_list/v4/24px.svg)      | Layer Manager      | Opens the Layers Manager panel, where you can select which layers to view. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/home/v4/24px.svg)      | Home      | Return to the data table so that you can open another slide.|
+| ![](https://fonts.gstatic.com/s/i/materialicons/create/v4/24px.svg)      | Draw      |	Draw thin lines, thick lines, or polygons on the image. To maintain the integrity of measurements, avoid drawing shapes that overlap or intersect one another. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/search/v4/24px.svg)       | Magnifier      |The Magnifier works like a magnifying glass and allows you to see the slide at normal magnification (1.0), low magnification (0.5), or high magnification (2.0). Click a magnification level and place the bounding box on the area of the slide you want to magnify. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/space_bar/v4/24px.svg)      | Measurement      | Drag this tool on the slide to learn the measurement in micrometers. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/share/v4/24px.svg)      | Share View      |Opens a window with a URL to the current presentation state of the slide including the magnification level, layers that are currently open, and your position on the image.|
+| ![](https://fonts.gstatic.com/s/i/materialicons/view_carousel/v4/24px.svg)      | Side by Side Viewer     |Shows the Layer Manager panel, the left and right layers, and inset window. For the right and left layer, select which layer you want to view. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/satellite/v4/24px.svg)      | Heatmap     |	For a slide with heatmap data, opens the choices of heatmaps available, as well as ways of displaying the heatmaps. The gradient shows all of the values on the selected spectrum for the field you selected. Contains a heatmap edit pen function.|
+| ![](https://fonts.gstatic.com/s/i/materialicons/label/v4/24px.svg)      | Labeling      |Use this tool to draw a circle or rectangle around a tumor region, measure an area on the slide, download labels, and submit a bug report. The Labeling tool has its own toolbar with tools in the following order from left to right: return to the previous slide, place a square on the slide, place a circle on the slide, measure an area, download labels, and submit a bug report. Click the left arrow at the far right of the toolbar to hide it, then click the right arrow to show it. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/timeline/v6/24px.svg)      | Segment      | This tool allows you to display, count, and export nuclear segmentations on the image. Clicking this tool opens the following custom toolbar. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/aspect_ratio/v4/24px.svg)      | Model      | Show results from a pre-trained tensorflow compatible model on a ROI of the slide. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/bug_report/v4/24px.svg)      | Bug Report      | Report a bug or give feedback. |
 
 
 ## Toolbar Shortcuts


### PR DESCRIPTION
The icons have been taken from https://material.io/resources/icons/.
The preview of new readme.md can be viewed at my repository - https://github.com/cjchirag7/caMicroscope/tree/readme-icons#using-tools

I hope this will help users to easily get an idea of the functions of all the tools. :)