### PR TITLE
Added validation in checkUserPermissions() to handle empty response

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -490,10 +490,14 @@
 	function checkUserPermissions(){
 		let userType=getUserType();
 		let permissions;
-		getUserPermissions(userType).then(function(response){
-			return response.json();   
-		}).then(function(data) {
-			// console.log(data);
+		getUserPermissions(userType)
+		.then(response => response.text())
+		.then((data) => {
+		return (data ? JSON.parse(data) : null);
+		})
+		.then((data)=> {
+			if(data===null)
+				return;
 			permissions = data;
 			if(permissions.slide.delete == true)
 				$(".DelButton").css("display","block");
@@ -501,7 +505,7 @@
 	}
 	function deleteSld(e) {
 		const oid = e.dataset.id;
-		const oname = e.dataset.name;		
+		const oname = e.dataset.name;
 		const store = new Store('../data/');
 		if (oid) {
 			$('#confirmDeleteContent').html(`Are you sure you want to delete the slide ${oname} with id ${oid} ?`);
@@ -509,7 +513,7 @@
 			$("#confirmDelete").unbind( "click" );
 			$("#confirmDelete").click(function(){
 				store.deleteSlide(oid);
-			});			
+			});
 		} else {
 			alert('No Data Id');
 		}


### PR DESCRIPTION
Prevent the error 'unexpected end of input' at response.json() in table.html.
Fixes #320 
Actually, this error was due to the fact that  'fetch' doesn't accept responses with empty body.