### PR TITLE
Store gradient/color information in DB [ Fixes #307 ]

### DIFF
--- a/apps/heatmap/init.js
+++ b/apps/heatmap/init.js
@@ -128,18 +128,11 @@ function initCore() {
 
         if ($D.heatMapData.provenance.analysis.setting) {
           opt.mode = $D.heatMapData.provenance.analysis.setting.mode;
-          if (
-            opt.mode === 'binal' &&
-            $D.heatMapData.provenance.analysis.setting.color
-          ) {
-            opt.color = $D.heatMapData.provenance.analysis.setting.color;
-          } else if (
-            opt.mode === 'gradient' &&
-            $D.heatMapData.provenance.analysis.setting.colors &&
-            $D.heatMapData.provenance.analysis.setting.colors.length>0
-          ) {
+          if (opt.mode === 'binal') {
+            opt.color = $D.heatMapData.provenance.analysis.setting.colors[0];
+          } else if (opt.mode === 'gradient') {
             opt.colors = $D.heatMapData.provenance.analysis.setting.colors;
-            opt.steps = $D.heatMapData.provenance.analysis.setting.colors.length+1;
+            opt.steps = $D.heatMapData.provenance.analysis.setting.colors.length + 1;
           }
           if ($D.heatMapData.provenance.analysis.setting.field) {
             opt.currentFieldName = $D.heatMapData.provenance.analysis.setting.field;

--- a/apps/heatmap/init.js
+++ b/apps/heatmap/init.js
@@ -123,11 +123,24 @@ function initCore() {
           editedData: $D.editedDataClusters,
           size: $D.heatMapData.provenance.analysis.size,
           fields: $D.heatMapData.provenance.analysis.fields,
-          color: '#253494', // inputs[3].value
+          color: '#1034A6', // inputs[3].value
         };
 
         if ($D.heatMapData.provenance.analysis.setting) {
           opt.mode = $D.heatMapData.provenance.analysis.setting.mode;
+          if (
+            opt.mode === 'binal' &&
+            $D.heatMapData.provenance.analysis.setting.color
+          ) {
+            opt.color = $D.heatMapData.provenance.analysis.setting.color;
+          } else if (
+            opt.mode === 'gradient' &&
+            $D.heatMapData.provenance.analysis.setting.colors &&
+            $D.heatMapData.provenance.analysis.setting.colors.length>0
+          ) {
+            opt.colors = $D.heatMapData.provenance.analysis.setting.colors;
+            opt.steps = $D.heatMapData.provenance.analysis.setting.colors.length+1;
+          }
           if ($D.heatMapData.provenance.analysis.setting.field) {
             opt.currentFieldName = $D.heatMapData.provenance.analysis.setting.field;
           }

--- a/apps/heatmap/uicallbacks.js
+++ b/apps/heatmap/uicallbacks.js
@@ -372,7 +372,14 @@ async function onUpdateHeatmapFields() {
     mode: $CAMIC.viewer.heatmap.mode,
   };
 
-  if ($CAMIC.viewer.heatmap.mode=='gradient') setting.field = $CAMIC.viewer.heatmap._currentField.name;
+  if ($CAMIC.viewer.heatmap.mode=='gradient') {
+    setting.field = $CAMIC.viewer.heatmap._currentField.name;
+    setting.colors = $CAMIC.viewer.heatmap._colors;
+    setting.color = null;
+  } else if ($CAMIC.viewer.heatmap.mode=='binal') {
+    setting.color = $CAMIC.viewer.heatmap._color;
+    setting.colors = [];
+  }
 
   const fields = $D.heatMapData.provenance.analysis.fields;
   const specimen = $D.heatMapData.provenance.image.specimen;

--- a/apps/heatmap/uicallbacks.js
+++ b/apps/heatmap/uicallbacks.js
@@ -375,10 +375,8 @@ async function onUpdateHeatmapFields() {
   if ($CAMIC.viewer.heatmap.mode=='gradient') {
     setting.field = $CAMIC.viewer.heatmap._currentField.name;
     setting.colors = $CAMIC.viewer.heatmap._colors;
-    setting.color = null;
   } else if ($CAMIC.viewer.heatmap.mode=='binal') {
-    setting.color = $CAMIC.viewer.heatmap._color;
-    setting.colors = [];
+    setting.colors = [$CAMIC.viewer.heatmap._color];
   }
 
   const fields = $D.heatMapData.provenance.analysis.fields;

--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -1295,7 +1295,7 @@ async function callback(data) {
           mode: 'binal',
           size: $D.heatMapData.provenance.analysis.size,
           fields: $D.heatMapData.provenance.analysis.fields,
-          color: '#253494', // inputs[3].value
+          color: '#1034A6', // inputs[3].value
         };
 
         if ($D.heatMapData.provenance.analysis.setting) {
@@ -1322,7 +1322,7 @@ async function callback(data) {
                   // editedData:$D.editedDataClusters,
                   size: $D.heatMapData.provenance.analysis.size,
                   fields: $D.heatMapData.provenance.analysis.fields,
-                  color: '#253494', // inputs[3].value
+                  color: '#1034A6', // inputs[3].value
                 };
 
                 if ($D.heatMapData.provenance.analysis.setting) {

--- a/components/heatmapcontrol/heatmapcontrol.js
+++ b/components/heatmapcontrol/heatmapcontrol.js
@@ -63,7 +63,9 @@ HeatmapControl.prototype.__refresh = function() {
   const template = `
     <div class='mode-panel'>
 
-        <label> Gradient <input type='checkbox' value='gradient' ${this.setting.mode == 'gradient'? 'checked':''} /></label>
+        <label> Gradient <input type='checkbox' value='gradient' ${
+          this.setting.mode == 'gradient' ? 'checked' : ''
+} /></label>
     </div>
     <div class='sel-field-panel'>
         <select></select>
@@ -78,10 +80,16 @@ HeatmapControl.prototype.__refresh = function() {
         </div>
     </div>
     <div class='color-panel'>
-        <label> Color <input id='heatMapColor' type='color' value='#1034A6' /></label>
+        <label> Color <input id='heatMapColor' type='color' value= ${
+          this.setting.mode === 'gradient' ?
+            '#1034A6' :
+            $CAMIC.viewer.heatmap._color
+} /></label>
     </div>
     <div class='colors-legend-panel'>
-        <label># of Intervals <input id='legendIntervals' type='number' class='range-enforced' value='5' min='2' max='10'/></label> <div class="warning" style="display: none;"></div>
+        <label># of Intervals <input id='legendIntervals' type='number' class='range-enforced' value=${
+          this.setting.mode === 'gradient' ? $CAMIC.viewer.heatmap._colors.length : 5
+} min='2' max='10'/></label> <div class="warning" style="display: none;"></div>
         <div class='legends'>
         </div>
     </div>
@@ -131,7 +139,8 @@ HeatmapControl.prototype.__refresh = function() {
 
   const legendIntervalsInput = colorsLegendPanel.querySelector('#legendIntervals');
   // Setting default value of intervals
-  legendIntervalsInput.value = 5;
+  legendIntervalsInput.value =
+    this.setting.mode === 'gradient' ? $CAMIC.viewer.heatmap._colors.length : 5;
   const noOfIntervals = legendIntervalsInput.value;
 
   const legendsContainer = colorsLegendPanel.querySelector('.legends');
@@ -327,6 +336,7 @@ function createOpacities(container, field, changeFunc) {
 // Create HTML Color inputs for given noOfIntervals
 function createIntervalInputs(container, noOfIntervals, changeFunc) {
   // Empty the container
+  let colors=[];
   while ( container.firstChild ) container.removeChild( container.firstChild );
   for (let i = 1; i <= noOfIntervals; i++) {
     const div = document.createElement('div');
@@ -336,14 +346,17 @@ function createIntervalInputs(container, noOfIntervals, changeFunc) {
     label.className = 'color-input';
     const color = document.createElement('input');
     color.type = 'color';
-    color.value = defaultColorList[getGradientColorIndex(i, noOfIntervals)];
+    color.value = $CAMIC.viewer.heatmap.mode==='gradient' ?
+      $CAMIC.viewer.heatmap._colors[i - 1] :
+      defaultColorList[getGradientColorIndex(i, noOfIntervals)];
     color.oninput = changeFunc;
     // Input for color legends.
     div.appendChild(label);
     div.appendChild(color);
-
+    colors.push(color.value);
     container.appendChild(div);
   }
+  $CAMIC.viewer.heatmap.setColors(colors);
 }
 // returns selected colors for intervals
 function getColors(container) {

--- a/components/heatmapcontrol/heatmapcontrol.js
+++ b/components/heatmapcontrol/heatmapcontrol.js
@@ -346,9 +346,11 @@ function createIntervalInputs(container, noOfIntervals, changeFunc) {
     label.className = 'color-input';
     const color = document.createElement('input');
     color.type = 'color';
-    color.value = $CAMIC.viewer.heatmap.mode==='gradient' ?
-      $CAMIC.viewer.heatmap._colors[i - 1] :
-      defaultColorList[getGradientColorIndex(i, noOfIntervals)];
+    if (i <= $CAMIC.viewer.heatmap._colors.length) {
+      color.value = $CAMIC.viewer.heatmap._colors[i - 1];
+    } else {
+      color.value = defaultColorList[i - 1];
+    }
     color.oninput = changeFunc;
     // Input for color legends.
     div.appendChild(label);

--- a/core/extension/osd-heatmap-overlay.js
+++ b/core/extension/osd-heatmap-overlay.js
@@ -76,7 +76,7 @@
     this.mode = options.mode || "binal";
     this._fields = createFields(options.fields);
     this._size = options.size;
-    this._steps = options.steps || 3;
+    this._steps = options.steps || 6;
     this._t_data = null;
     this._operator = "AND";
     this._currentField = options.currentField || this._fields[0];
@@ -88,8 +88,14 @@
         f => f.name === options.currentFieldName
       );
     }
-    this._color = options.color || "#045a8d"; // heatmap color
-    this._colors = options.colors || ["#edf8e9", "#006d2c"]; // heatmap color
+    this._color = options.color || '#1034a6'; // heatmap color
+    this._colors = options.colors || [
+      '#D4E6F1',
+      '#7FB3D5',
+      '#2980B9',
+      '#1F618D',
+      '#154360',
+    ]; // heatmap color
     this.intervals = _getIntervals(
       this._currentField,
       this._colors,
@@ -185,7 +191,7 @@
           this.__legend_info.style.width = "";
           this.__legend_info.style.height = "";
         }
-      }.bind(this)
+      }.bind(this),
     );
     this.__legend.style.display = "none";
 
@@ -226,8 +232,14 @@
           f => f.name === options.currentFieldName
         );
       }
-      this._color = options.color || this._color || "#006d2c";
-      this._colors = options.colors || ["#FFFFFF", "#1034A6"];
+      this._color = options.color || this._color || '#1034a6';
+      this._colors = options.colors || this._colors || [
+        '#D4E6F1',
+        '#7FB3D5',
+        '#2980B9',
+        '#1F618D',
+        '#154360',
+      ];
       this.intervals = _getIntervals(
         this._currentField,
         this._colors,
@@ -597,12 +609,15 @@
       const y = d[1]; // top
 
       // current view's bounding box against a patch
+      if (this._getCanvasBoundBox)
       return $.isIntersectBbox(this._getCanvasBoundBox, {
         x: x,
         y: y,
         width: this._size[0],
         height: this._size[1]
       });
+      else
+        console.log(this._getCanvasBoundBox);
     },
     /**
      * [filter description]
@@ -802,16 +817,30 @@
     return ps;
   }
 
-  function _getIntervals(field, colors = ["#FFFFFF", "#000000"], steps = 3) {
+  function _getIntervals(
+    field,
+    colors = ['#D4E6F1', '#7FB3D5', '#2980B9', '#1F618D', '#154360'],
+    steps = 6
+  ) {
     // get list of colors
     //
     // const colorList = interpolateColors(hexToRgb(colors[0]),hexToRgb(colors[1]),steps);
 
     // Default preset of colors
-    const defaultColorList = ["#2b83ba", "#abdda4", "#ffffbf", "#fdae61", "#d7191c"];
+    const defaultColorList = [
+      '#D4E6F1',
+      '#7FB3D5',
+      '#2980B9',
+      '#1F618D',
+      '#154360',
+    ];
 
-    if(colors.length + 1 != steps){
-      console.log(`Number of colors ${colors.length + 1 } required for steps ${steps} are not right. Switch to default colors`)
+    if (colors.length + 1 != steps) {
+      console.log(
+        `Number of colors ${
+          colors.length + 1
+        } required for steps ${steps} are not right. Switch to default colors`
+      );
       colors = defaultColorList;
       steps = defaultColorList.length + 1;
     }
@@ -822,7 +851,7 @@
     //const colorList = ['#fee5d9','#fcae91','#fb6a4a','#de2d26','#a50f15'];
     // const colorList = ['#feedde','#fdbe85','#fd8d3c','#e6550d','#a63603'];
     //const colorList = ['#edf8e9','#bae4b3','#74c476','#31a354','#006d2c'];
-     
+
     // get a boundary list of intervals
     const threstholds = field.value;
     const boundaries = interpolateNums(

--- a/core/extension/osd-heatmap-overlay.js
+++ b/core/extension/osd-heatmap-overlay.js
@@ -89,13 +89,7 @@
       );
     }
     this._color = options.color || '#1034a6'; // heatmap color
-    this._colors = options.colors || [
-      '#D4E6F1',
-      '#7FB3D5',
-      '#2980B9',
-      '#1F618D',
-      '#154360',
-    ]; // heatmap color
+    this._colors = options.colors || ['#EAF2F8', '#D4E6F1', '#A9CCE3', '#7FB3D5', '#5499C7']; // heatmap color
     this.intervals = _getIntervals(
       this._currentField,
       this._colors,
@@ -233,13 +227,7 @@
         );
       }
       this._color = options.color || this._color || '#1034a6';
-      this._colors = options.colors || this._colors || [
-        '#D4E6F1',
-        '#7FB3D5',
-        '#2980B9',
-        '#1F618D',
-        '#154360',
-      ];
+      this._colors = options.colors || this._colors || ['#EAF2F8', '#D4E6F1', '#A9CCE3', '#7FB3D5', '#5499C7'];
       this.intervals = _getIntervals(
         this._currentField,
         this._colors,
@@ -819,7 +807,7 @@
 
   function _getIntervals(
     field,
-    colors = ['#D4E6F1', '#7FB3D5', '#2980B9', '#1F618D', '#154360'],
+    colors = ['#EAF2F8', '#D4E6F1', '#A9CCE3', '#7FB3D5', '#5499C7'],
     steps = 6
   ) {
     // get list of colors
@@ -827,13 +815,7 @@
     // const colorList = interpolateColors(hexToRgb(colors[0]),hexToRgb(colors[1]),steps);
 
     // Default preset of colors
-    const defaultColorList = [
-      '#D4E6F1',
-      '#7FB3D5',
-      '#2980B9',
-      '#1F618D',
-      '#154360',
-    ];
+    const defaultColorList = ['#EAF2F8', '#D4E6F1', '#A9CCE3', '#7FB3D5', '#5499C7'];
 
     if (colors.length + 1 != steps) {
       console.log(
@@ -865,7 +847,7 @@
       rs.push({
         color: colors[i],
         range: [boundaries[i], boundaries[i + 1]],
-        data: []
+        data: [],
       });
     }
     return rs;


### PR DESCRIPTION
Fixes #307 
To store the colors , provenance.analysis.setting will have a new field 'colors'
- When mode is 'binal', length of colors is 1
- When mode is 'gradient', length of colors is >=2

The query which was earlier something like -
```
{"provenance.analysis.fields":[{"name":"necrosis","range":[0,1],"value":[0,1]},{"name":"tumor","range":[0,10],"value":[0,10]}],"provenance.analysis.setting":{"mode":"gradient","field":"necrosis"}}
```
is modified to -
```
{"provenance.analysis.fields":[{"name":"necrosis","range":[0,1],"value":[0,1]},{"name":"tumor","range":[0,10],"value":[0,10]}],"provenance.analysis.setting":{"mode":"gradient","field":"necrosis",colors":["#F23112","#553172","#333117" ] }}
```

In case, when mode is 'binal', the value of `color[0]` is the selected color .
