### PR TITLE
fix popup close on hidden segment

### DIFF
--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -1377,7 +1377,8 @@ async function callback(data) {
       loadAnnotationById(camic, d, null);
     } else {
       if (!d.layer) d.layer = camic.viewer.omanager.addOverlay(item);
-      if (!d.isShow) $UI.annotPopup.close();
+      // remove popup if segment is hidden
+      if ($UI.annotPopup.data && !d.isShow && $UI.annotPopup.data.id===d.item.id) $UI.annotPopup.close();
       d.layer.isShow = d.isShow;
       camic.viewer.omanager.updateView();
     }

--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -1377,6 +1377,7 @@ async function callback(data) {
       loadAnnotationById(camic, d, null);
     } else {
       if (!d.layer) d.layer = camic.viewer.omanager.addOverlay(item);
+      if (!d.isShow) $UI.annotPopup.close();
       d.layer.isShow = d.isShow;
       camic.viewer.omanager.updateView();
     }


### PR DESCRIPTION
After hiding a segment popup still used to stick on the screen.
 
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/29784549/78550698-1f71e300-7822-11ea-897d-7d1466b1d9f3.gif)

After this fix the popup will close as soon as the corresponding segment hides.

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/29784549/78550709-26005a80-7822-11ea-8c74-e55de2e267a5.gif)

