### PR TITLE
Clean loader code and increase upload modal width

### DIFF
--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -69,25 +69,22 @@ async function handleUpload(selectedFiles) {
     idtr.deleteCell(1);
   }
 
-  var currID = 0;
   // Add columns
-  for (var i=0; i<selectedFiles.length; i++, currID++) {
-    idtr.insertCell(-1).innerHTML = '<b>'+Number(currID+1)+'<b>';
-    fnametr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=filename id='filename${currID}'
-    onchange=hideCheckButton();hidePostButton(); value='${selectedFiles[i]['name']}'>`;
-    tokentr.insertCell(-1).innerHTML = `<input type=text class="form-control" onchange=hideCheckButton();hidePostButton();
-    disabled name=token id='token${currID}'>`;
-    slidetr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=slidename id='slidename${currID}'>`;
-    filtertr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=filter id='filter${currID}'>`;
+  idtr.insertCell(-1).innerHTML = '<b>'+Number(1)+'<b>';
+  fnametr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=filename id='filename0'
+  onchange=hideCheckButton();hidePostButton(); value='${selectedFiles[0]['name']}'>`;
+  tokentr.insertCell(-1).innerHTML = `<input type=text class="form-control" onchange=hideCheckButton();hidePostButton();
+  disabled name=token id='token0'>`;
+  slidetr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=slidename id='slidename0'>`;
+  filtertr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=filter id='filter0'>`;
 
-    selectedFile = selectedFiles[i];
-    const filename = document.getElementById('filename'+currID).value;
-    const token = await startUpload(filename);
-    const callback = continueUpload(token);
-    document.getElementById('token'+currID).value = token;
-    readFileChunks(selectedFile, token);
-    // parseFile(selectedFile, callback, 0, x=>(changeStatus("UPLOAD", "Finished Reading File")))
-  }
+  selectedFile = selectedFiles[0];
+  const filename = document.getElementById('filename'+0).value;
+  const token = await startUpload(filename);
+  const callback = continueUpload(token);
+  document.getElementById('token'+0).value = token;
+  readFileChunks(selectedFile, token);
+  // parseFile(selectedFile, callback, 0, x=>(changeStatus("UPLOAD", "Finished Reading File")))
 
   document.getElementById('fileUploadInput').colSpan = selectedFiles.length;
   document.getElementById('controlButtons').colSpan = selectedFiles.length+1;
@@ -117,64 +114,61 @@ function continueUpload(token) {
 }
 function finishUpload() {
   var reset = true;
-  for (var i=0; i<document.getElementById('fileIdRow').cells.length-1; i++) {
-    const token = document.getElementById('token'+i).value;
-    const filename = document.getElementById('filename'+i).value;
-    if (token === oldToken) {
-      tokenChange=false;
-    } else {
-      tokenChange=true;
-      oldToken=token;
-    }
-    if (filename === oldFilename) {
-      filenameChange = false;
-    } else {
-      filenameChange=true;
-      oldFilename=filename;
-    }
-    if (!filenameChange && !tokenChange) {
-      if (finishUploadSuccess) {
-        changeStatus('UPLOAD', 'You have already uploaded this file just now.');
-        if (checkSuccess) {
-          $('#check_btn').show();
-          $('#post_btn').show();
-        }
-      }
-      return;
-    }
-    const body = {filename: filename};
-    changeStatus('UPLOAD', 'Finished Reading File, Posting');
-    const regReq = fetch(finishUrl + token, {method: 'POST', body: JSON.stringify(body), headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-    }});
-    console.log(i);
-    regReq.then((x)=>x.json()).then((a)=>{
-      changeStatus('UPLOAD | Finished', a, reset); reset = false;
-      console.log(a);
-      if (typeof a === 'object' && a.error) {
-        finishUploadSuccess = false;
-        $('#check_btn').hide();
-        $('#post_btn').hide();
-      } else {
-        finishUploadSuccess=true;
-        if (checkSuccess===true) {
-          $('#check_btn').show();
-          $('#post_btn').show();
-        } else {
-          $('#check_btn').show();
-          $('#post_btn').hide();
-        }
-      }
-    });
-    regReq.then((e)=> {
-      if (e['ok']===false) {
-        finishUploadSuccess = false;
-        $('#check_btn').hide();
-        $('#post_btn').hide();
-        changeStatus('UPLOAD | ERROR;', e);
-        reset = true;
-        console.log(e);
-      }
-    });
+  const token = document.getElementById('token'+0).value;
+  const filename = document.getElementById('filename'+0).value;
+  if (token === oldToken) {
+    tokenChange=false;
+  } else {
+    tokenChange=true;
+    oldToken=token;
   }
+  if (filename === oldFilename) {
+    filenameChange = false;
+  } else {
+    filenameChange=true;
+    oldFilename=filename;
+  }
+  if (!filenameChange && !tokenChange) {
+    if (finishUploadSuccess) {
+      changeStatus('UPLOAD', 'You have already uploaded this file just now.');
+      if (checkSuccess) {
+        $('#check_btn').show();
+        $('#post_btn').show();
+      }
+    }
+    return;
+  }
+  const body = {filename: filename};
+  changeStatus('UPLOAD', 'Finished Reading File, Posting');
+  const regReq = fetch(finishUrl + token, {method: 'POST', body: JSON.stringify(body), headers: {
+    'Content-Type': 'application/json; charset=utf-8',
+  }});
+  regReq.then((x)=>x.json()).then((a)=>{
+    changeStatus('UPLOAD | Finished', a, reset); reset = false;
+    console.log(a);
+    if (typeof a === 'object' && a.error) {
+      finishUploadSuccess = false;
+      $('#check_btn').hide();
+      $('#post_btn').hide();
+    } else {
+      finishUploadSuccess=true;
+      if (checkSuccess===true) {
+        $('#check_btn').show();
+        $('#post_btn').show();
+      } else {
+        $('#check_btn').show();
+        $('#post_btn').hide();
+      }
+    }
+  });
+  regReq.then((e)=> {
+    if (e['ok']===false) {
+      finishUploadSuccess = false;
+      $('#check_btn').hide();
+      $('#post_btn').hide();
+      changeStatus('UPLOAD | ERROR;', e);
+      reset = true;
+      console.log(e);
+    }
+  });
 }

--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -55,22 +55,19 @@ async function handleUpload(selectedFiles) {
   var fnametr = document.getElementById('filenameRow');
   var tokentr = document.getElementById('tokenRow');
   var slidetr = document.getElementById('slidenameRow');
-  var idtr = document.getElementById('fileIdRow');
   var filtertr = document.getElementById('filterRow');
 
   // Clear existing
   document.getElementById('json_table').innerHTML = '';
-  var n = idtr.cells.length;
+  var n = tokentr.cells.length;
   for (var i=0; i<n-1; i++) {
     fnametr.deleteCell(1);
     tokentr.deleteCell(1);
     slidetr.deleteCell(1);
     filtertr.deleteCell(1);
-    idtr.deleteCell(1);
   }
 
   // Add columns
-  idtr.insertCell(-1).innerHTML = '<b>'+Number(1)+'<b>';
   fnametr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=filename id='filename0'
   onchange=hideCheckButton();hidePostButton(); value='${selectedFiles[0]['name']}'>`;
   tokentr.insertCell(-1).innerHTML = `<input type=text class="form-control" onchange=hideCheckButton();hidePostButton();

--- a/apps/loader/loader.js
+++ b/apps/loader/loader.js
@@ -183,19 +183,13 @@ function UploadBtn() {
 }
 
 function CheckBtn() {
-  for (var i=0; i<document.getElementById('fileIdRow').cells.length-1; i++) {
-    var filename = document.getElementById('filename'+i).value;
-    if (i==0) handleCheck(filename, true, i+1);
-    else handleCheck(filename, false, i+1);
-  }
+  var filename = document.getElementById('filename'+0).value;
+  handleCheck(filename, true, 1);
 }
 
 function PostBtn() {
-  for (var i=0; i<document.getElementById('fileIdRow').cells.length-1; i++) {
-    var filename = document.getElementById('filename'+i).value;
-    var slidename = document.getElementById('slidename'+i).value;
-    var filter = document.getElementById('filter'+i).value;
-    if (i==0) handlePost(filename, slidename, filter, true);
-    else handlePost(filename, slidename, false);
-  }
+  var filename = document.getElementById('filename'+0).value;
+  var slidename = document.getElementById('slidename'+0).value;
+  var filter = document.getElementById('filter'+0).value;
+  handlePost(filename, slidename, filter, true);
 }

--- a/apps/table.css
+++ b/apps/table.css
@@ -19,7 +19,7 @@
 }
 
 nav li{
-	transition: background 0.5s; 
+	transition: background 0.5s;
 	border-radius: 3px;
 }
 nav li:not(:first-child){
@@ -49,4 +49,7 @@ nav li:not(.active):hover a{
 }
 .DelButton{
 	display: none;
+}
+.custom-file-input{
+	cursor: pointer;
 }

--- a/apps/table.html
+++ b/apps/table.html
@@ -177,7 +177,7 @@
 									<form id="upload-form">
 										<table class="table table-borderless" cellpadding="5" cellspacing="0">
 											<tr>
-												<td align="right"><b>Files</b></td>
+												<td align="right"><b>File</b></td>
 												<td id="fileUploadInput">
 														<span class="input-group mb-3" >
 															<span class="custom-file">

--- a/apps/table.html
+++ b/apps/table.html
@@ -187,9 +187,6 @@
 														</span>
 													</td>
 											</tr>
-											<tr id="fileIdRow">
-												<td align="right"><b>ID</b></td>
-											</tr>
 											<tr id="filenameRow">
 												<td align="right"><b>Filename</b></td>
 											</tr>

--- a/apps/table.html
+++ b/apps/table.html
@@ -151,7 +151,7 @@
 
 			<div class="modal fade" id="upload-dialog" tabindex="-1" role="dialog"
 			aria-labelledby="title-of-dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-			<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" role="document">
+			<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg" role="document">
 				<div class="modal-content">
 					<div class="modal-header">
 						<h5 class="modal-title" id="title-of-dialog">Upload New Slide</h5>
@@ -347,6 +347,7 @@
 		$('#filterRow').children().slice(1).remove();
 		$('#json_table').html('');
 		$('#load_status').html('');
+		$('.custom-file-label').html('');
 	}
 
 	function initialize() {


### PR DESCRIPTION
Closes #326 
This includes the following changes :
- Refactored loader code to support only a single file upload, at a time
- Cursor has been made :point_up_2: when users hovers over the 'choose file' (browse) button in the modal
- The resetUploadForm() has been modified, in accordance with #325 
- The upload modal width is increased
After increased width, the modal look like this, on an average PC -
![wide-modal](https://user-images.githubusercontent.com/45796806/78553161-74aff380-7826-11ea-8480-2fdf4ca5a939.png)
