### PR TITLE
Convert space to underscore and validate extension, on change of filename

### DIFF
--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -69,7 +69,8 @@ async function handleUpload(selectedFiles) {
 
   // Add columns
   fnametr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=filename id='filename0'
-  onchange=hideCheckButton();hidePostButton(); value='${selectedFiles[0]['name']}'>`;
+  onchange=fileNameChange(); value='${selectedFiles[0]['name']}'>`;
+  fileNameChange();
   tokentr.insertCell(-1).innerHTML = `<input type=text class="form-control" onchange=hideCheckButton();hidePostButton();
   disabled name=token id='token0'>`;
   slidetr.insertCell(-1).innerHTML = `<input type=text class="form-control" name=slidename id='slidename0'>`;

--- a/apps/table.html
+++ b/apps/table.html
@@ -621,6 +621,34 @@
 		}
 	}
 
+	function fileNameChange()
+	{
+		hideCheckButton(); hidePostButton();
+		const fileNameInput = $('#filename0');
+		const fileName = fileNameInput.val();
+		let newFileName = fileName.split(" ").join("_");
+		fileNameInput.val(newFileName);
+		let fileExtension = newFileName.toLowerCase().split('.').reverse()[0];
+		if (!allowedExtensions.includes(fileExtension)) {
+			fileNameInput.addClass('is-invalid');
+			if(fileNameInput.parent().children().length===1)
+			{
+				fileNameInput.parent().append(`<div class="invalid-feedback" id="filename-feedback0">
+					${fileExtension} files are not compatible  </div>`);
+			}
+			else
+			{
+				$('#filename-feedback0').html(`${ fileExtension } files are not compatible`)
+			}
+		}
+		else
+		{
+			fileNameInput.removeClass('is-invalid');
+			if (fileNameInput.parent().children().length !== 1) {
+			$('#filename-feedback0').remove();
+			}
+		}
+	}
 
 	document.addEventListener('DOMContentLoaded', initialize);
 </script>


### PR DESCRIPTION
Closes #343 
Added the following features
- Convert spaces (' ') to underscores('_') on 'change' event in FileName.
- Validate the extension on 'change' event in FileName and display error message, appropriately

**Screencast**
![space-extension-check-new](https://user-images.githubusercontent.com/45796806/78706604-fab66200-792c-11ea-9341-027e5424e496.gif)
