### PR TITLE
Improved sorting of datatables [Fixes #357]

### DIFF
--- a/apps/table.css
+++ b/apps/table.css
@@ -50,6 +50,6 @@ nav li:not(.active):hover a{
 .DelButton{
 	display: none;
 }
-.custom-file-input{
+.custom-file-input, .sort-btn {
 	cursor: pointer;
 }

--- a/apps/table.html
+++ b/apps/table.html
@@ -59,7 +59,6 @@
 			}
 			//Sanitizing input
 			slide.value = sanitize(slide.value);
-			console.log(existingSlideNames,slide.value);
 			//Checking if silde with given name already exists
 			if(existingSlideNames.includes(slide.value)) {
 				changeStatus("UPLOAD", "Slide with given name already exists");
@@ -372,7 +371,7 @@
 							else if (!d[key]) rs.push('')
 							else rs.push(d[key])
 						});
-						const btn = `<div id='open-delete'> <button class="btn btn-success" data-id='${rs[0]}' onclick='openView(this)'>Open</button> 
+						const btn = `<div id='open-delete'> <button class="btn btn-success" data-id='${rs[0]}' onclick='openView(this)'>Open</button>
 							<button type='button' class='btn btn-info DownloadButton' id='downloadBtn' data-id='${rs[0]}' onclick='downloadSlide(this)' > <i class='fas fa-download' ></i> </button>
 							<button type='button' class='btn btn-danger DelButton' id='deleteBtn' data-id='${rs[0]}' data-name='${rs[1]}' onclick='deleteSld(this)' data-toggle='modal'> <i class='fas fa-trash-alt' ></i> </button></div>`
 						rs.push(btn);
@@ -402,9 +401,9 @@
 				//Adding names to later validate for new slide names
 				existingSlideNames = data.map(d => d[1]);
 
-				const thead = HeadMapping.map(d => "<th>" + d.title + `<img id='sort1${d.title}' class='float-right sort-btn' width='10px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVRIie3XsQrCMBSF4T+CoJsddHAo9HH6AD634NbNqTgo6FI6WQdTtJLQpG0CxXsglIRyv0ugCYWZRsUGd8ARKIA0FroFTkCjxxnIYqNRcBsaFO9Dg+Cu6KS4LzoJrnh/Mr5oOwpgaSu+GNqVY6wHTN/Jo4DNz1oJrAzv7oH6a/4Ani7duabCvLVrnyKht1pggQUWWOA/g0vD2o3ulRgkOXDhcx1egYNvkTG/IIl+3nUD88gLIHVaGvUECUcAAAAASUVORK5CYII='/>
+				const thead = HeadMapping.map(d => "<th>" + d.title + `<img id='sort1${d.title}' class='float-right sort-btn' width='15px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVRIie3XsQrCMBSF4T+CoJsddHAo9HH6AD634NbNqTgo6FI6WQdTtJLQpG0CxXsglIRyv0ugCYWZRsUGd8ARKIA0FroFTkCjxxnIYqNRcBsaFO9Dg+Cu6KS4LzoJrnh/Mr5oOwpgaSu+GNqVY6wHTN/Jo4DNz1oJrAzv7oH6a/4Ani7duabCvLVrnyKht1pggQUWWOA/g0vD2o3ulRgkOXDhcx1egYNvkTG/IIl+3nUD88gLIHVaGvUECUcAAAAASUVORK5CYII='/>
 
-				<img id='sort2${d.title}' class='float-right sort-btn' width='10px' src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAs0lEQVRIie3VsQrCMBSF4T/qoFsddBR8Hncf24KTUAquDg4ugoPWwRbSEk2aJhHlHsiQhPCdZAl8KeMBZ+fADLgF6mLNBjgBVT3OwDYFXGqojqvY8NUAV7ye3Tmj8L0EFlhggQX+F3hi2VdAZlgzJQOm2vwCPDx7kWP+Al1G0SnSyqenVsDdt3Ed7xsvgD39b3sE1kMa++BB0L54UNQVj4La8KjoOzwJ2mQJ7IADsEqF/nae93FcRiryrh8AAAAASUVORK5CYII="/>
+				<img id='sort2${d.title}' class='float-right sort-btn' width='15px' src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAs0lEQVRIie3VsQrCMBSF4T/qoFsddBR8Hncf24KTUAquDg4ugoPWwRbSEk2aJhHlHsiQhPCdZAl8KeMBZ+fADLgF6mLNBjgBVT3OwDYFXGqojqvY8NUAV7ye3Tmj8L0EFlhggQX+F3hi2VdAZlgzJQOm2vwCPDx7kWP+Al1G0SnSyqenVsDdt3Ed7xsvgD39b3sE1kMa++BB0L54UNQVj4La8KjoOzwJ2mQJ7IADsEqF/nae93FcRiryrh8AAAAASUVORK5CYII="/>
 				</th>`);
 
 				thead.push("<th></th>");
@@ -495,7 +494,29 @@
 				$(trs).sort(function(a, b) {
 					let at=$(a).children('td').get(index).textContent.toLowerCase();
 					let bt=$(b).children('td').get(index).textContent.toLowerCase();
-					return upordown == 1 ? at > bt: at < bt;
+					if(!isNaN(at)&&!isNaN(bt))
+						{
+							at=Number(at);
+							bt=Number(bt);
+						}
+					if(upordown===1)
+					{
+						if(at>bt)
+							return 1;
+						else if(at<bt)
+							return -1;
+						else
+							return 0;
+					}
+					else
+					{
+						if (at < bt)
+							return 1;
+						else if (at > bt)
+							return -1;
+						else
+							return 0;
+					}
 				}).appendTo("#datatables > tbody");
 				selectedpage = 0;
 				showTablePage();
@@ -611,7 +632,7 @@
 		const oid = e.dataset.id;
 		handleDownload(oid);
 	}
-	
+
 	function deleteSld(e) {
 		const oid = e.dataset.id;
 		const oname = e.dataset.name;


### PR DESCRIPTION
Fixes #357 
The following changes have been made :
- Modified the comparator function to return -1, +1 or 0, depending upon the comparison of the elements
- If the values can be converted to number, then they would be first converted to number, and then the comparison would occur. Currently, the comparison, was done, taking them all, as strings, in lexicographical order. But there might be some cases like :   '2' > '12' (lexicographically)  but 2 < 12 (numerically) , which may produce undesired results to the user.
- Made the cursor to a :point_up_2: , when user hovers over the up/down button 
- Increased the size of up and down buttons from 10px to 15px, so that they are visible
- Now, the sort works perfectly, in both Chrome and Firefox