### PR TITLE
Implementation of Rotation Bar

### DIFF
--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -326,6 +326,7 @@ function presetLabelOn(label) {
     label.color;
   // close layers menu
   $UI.layersSideMenu.close();
+  rotationOff();
 }
 
 function presetLabelOff() {
@@ -348,6 +349,7 @@ function presetLabelOff() {
       '';
     $CAMIC.status = null;
   }
+  rotationOn();
 }
 
 function toolsOff() {
@@ -419,6 +421,7 @@ function annotationOn(state, target) {
   const input = $UI.annotOptPanel._form_.querySelector('#name');
   input.focus();
   input.select();
+  rotationOff();
 }
 
 function annotationOff() {
@@ -438,6 +441,7 @@ function annotationOff() {
     toggleOffDrawBtns();
     $CAMIC.status = null;
   }
+  rotationOn();
 }
 
 function toggleOffDrawBtns() {
@@ -566,6 +570,7 @@ function measurementOn() {
   const li = $UI.toolbar.getSubTool('measurement');
   li.querySelector('input[type=checkbox]').checked = true;
   $CAMIC.status = 'measure';
+  rotationOff();
 }
 
 function measurementOff() {
@@ -573,7 +578,23 @@ function measurementOff() {
   $CAMIC.viewer.measureInstance.off();
   const li = $UI.toolbar.getSubTool('measurement');
   li.querySelector('input[type=checkbox]').checked = false;
+  rotationOn();
+}
+
+function rotationOff(){
+  const sup = $CAMIC.viewer.rotateBar.txtR.childNodes[1]
+  $CAMIC.viewer.rotateBar.txtR.innerHTML = '0';
+  $CAMIC.viewer.rotateBar.txtR.appendChild(sup);
+  $CAMIC.viewer.rotateBar.range.value = '0';
+  $CAMIC.viewer.rotateBar.range.disabled = true;
+  $CAMIC.viewer.viewport.setRotation(0);
+  $CAMIC.viewer.rotateBar.divElt.style.opacity = 0.5;
+}
+
+function rotationOn(){
+  $CAMIC.viewer.rotateBar.range.disabled = false;
   $CAMIC.status = null;
+  $CAMIC.viewer.rotateBar.divElt.style.opacity = 1;
 }
 
 // --- toggle magnifier callback ---//

--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -578,11 +578,12 @@ function measurementOff() {
   $CAMIC.viewer.measureInstance.off();
   const li = $UI.toolbar.getSubTool('measurement');
   li.querySelector('input[type=checkbox]').checked = false;
+  $CAMIC.status = null;
   rotationOn();
 }
 
-function rotationOff(){
-  const sup = $CAMIC.viewer.rotateBar.txtR.childNodes[1]
+function rotationOff() {
+  const sup = $CAMIC.viewer.rotateBar.txtR.childNodes[1];
   $CAMIC.viewer.rotateBar.txtR.innerHTML = '0';
   $CAMIC.viewer.rotateBar.txtR.appendChild(sup);
   $CAMIC.viewer.rotateBar.range.value = '0';
@@ -591,9 +592,8 @@ function rotationOff(){
   $CAMIC.viewer.rotateBar.divElt.style.opacity = 0.5;
 }
 
-function rotationOn(){
+function rotationOn() {
   $CAMIC.viewer.rotateBar.range.disabled = false;
-  $CAMIC.status = null;
   $CAMIC.viewer.rotateBar.divElt.style.opacity = 1;
 }
 

--- a/apps/viewer/viewer.html
+++ b/apps/viewer/viewer.html
@@ -144,6 +144,12 @@
       media="all"
       href="../../core/extension/openseadragon-zoom-control/openseadragon-zoom-control.css"
     />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      media="all"
+      href="../../core/openseadragon-rotation.css"
+    />
     <!-- mesurement tool css -->
     <link
       rel="stylesheet"
@@ -302,6 +308,10 @@
     <script
       type="text/javascript"
       src="../../core/extension/openseadragon-zoom-control/openseadragon-zoom-control.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="../../core/openseadragon-rotation.js"
     ></script>
     <script
       type="text/javascript"

--- a/core/CaMic.js
+++ b/core/CaMic.js
@@ -92,7 +92,11 @@ class CaMic {
         }
 
         this.viewer.viewport.panTo(pt, true);
-
+        this.viewer.viewport.setRotation(states.a);
+        const sup = this.viewer.rotateBar.txtR.childNodes[1];
+        this.viewer.rotateBar.txtR.innerHTML = String(states.a);
+        this.viewer.rotateBar.txtR.appendChild(sup);
+        this.viewer.rotateBar.range.value = String(states.a);
         // set a position mark
         if (states.hasMark) {
           // create a mark

--- a/core/CaMic.js
+++ b/core/CaMic.js
@@ -126,7 +126,7 @@ class CaMic {
     // create draw pulgin
     this.createCanvasDraw();
     this.createOverlayers();
-
+    this.createRotationBar();
 
     // change navigator style
     if (this.setting.showNavigator) {
@@ -234,6 +234,9 @@ class CaMic {
       position: 'BOTTOM_RIGHT',
       autoFade: false,
     });
+  }
+  createRotationBar() {
+    this.viewer.rotationBar({});
   }
   /**
    * set up a canvas Draw functionality on the image

--- a/core/StatesHelper.js
+++ b/core/StatesHelper.js
@@ -37,6 +37,7 @@ class StatesHelper {
     }
     // get current zoom
     states.z = $CAMIC.viewer.viewport.getZoom(true);
+    states.a = $CAMIC.viewer.viewport.getRotation(true);
     if ($CAMIC.viewer.omanager) {
       const lays = $CAMIC.viewer.omanager.overlays.reduce(function(rs, lay) {
         if (lay.isShow)rs.push(lay.id);

--- a/core/openseadragon-rotation.css
+++ b/core/openseadragon-rotation.css
@@ -1,0 +1,22 @@
+.Rotation{
+    position: relative;
+    margin: 0px 0px 5px;
+    display: flex;
+    width: 100%;
+    height: 2.4rem;
+    background-color: rgb(54, 95, 156);
+}
+.idxR{
+    color: rgba(255,255,255,1);
+    min-width: 4.8rem;
+    height: 2.4rem;
+}
+.txtR{
+  z-index: 9;
+  position: relative;
+  float: left;
+  top: 50%;
+  left: 50%;
+  font-size: 1.3rem;
+  transform: translate(-50%, -50%);
+}

--- a/core/openseadragon-rotation.js
+++ b/core/openseadragon-rotation.js
@@ -1,0 +1,62 @@
+(function($){
+  if (!$.version || $.version.major < 2) {
+    throw new Error('This version of OpenSeadragonScalebar requires ' +
+                'OpenSeadragon version 2.0.0+');
+  }
+  $.Viewer.prototype.rotationBar = function(options){
+    options = options || {};
+    options.viewer = this;
+    this.rotateBar = new $.RotationBar(options);
+  }
+  $.RotationBar = function(options){
+    options = options || {};
+    if(!options.viewer){
+      throw new Error('A viewer must be specified.');
+    }
+    this.viewer = options.viewer;
+    this.divElt = document.createElement('div');
+    console.log(this.viewer.navigator.element.parentElement);
+    this.viewer.navigator.element.parentElement.appendChild(this.divElt);
+    this.divElt.className = 'Rotation';
+    this.roticon = document.createElement('div');
+    this.roticon.classList.add('material-icons');
+    this.roticon.classList.add('md-24');
+    this.roticon.classList.add('loop');
+    this.roticon.textContent = 'loop';
+    this.roticon.style.marginLeft = '2px';
+    this.roticon.style.fontSize = '2rem';
+    this.roticon.style.marginBottom = 'auto';
+    this.roticon.style.marginTop = 'auto';
+    this.roticon.style.padding = '2px';
+    this.range = $.makeNeutralElement( 'input' );
+    this.range.type = 'range';
+    this.range.min = '-180';
+    this.range.max = '180';
+    this.range.value = '0';
+    this.range.style.width = '78%';
+    this.range.style.height = '2.4rem';
+    this.range.style.marginLeft = '4px';
+    this.idxR = document.createElement( 'div' );
+    this.idxR.classList.add('idxR');
+    this.txtR = document.createElement('div');
+    this.txtR.classList.add('txtR');
+    this.txtR.innerHTML = '0'
+    this.degree = document.createElement('sup');
+    this.degree.innerHTML = 'o';
+    this.degree.style.marginLeft = '2px';
+    this.txtR.appendChild(this.degree);
+    this.idxR.appendChild(this.txtR);
+    this.divElt.appendChild(this.roticon);
+    this.divElt.appendChild(this.range);
+    this.divElt.appendChild(this.idxR);
+    const idk=this.txtR;
+    const sup = this.degree;
+    const view = this.viewer;
+    this.range.oninput = function(){
+      idk.innerHTML = this.value;
+      idk.appendChild(sup);
+      var intValue = parseInt(this.value);
+      view.viewport.setRotation(intValue);
+    }
+  }
+}(OpenSeadragon))

--- a/core/openseadragon-rotation.js
+++ b/core/openseadragon-rotation.js
@@ -1,16 +1,16 @@
-(function($){
+(function($) {
   if (!$.version || $.version.major < 2) {
     throw new Error('This version of OpenSeadragonScalebar requires ' +
                 'OpenSeadragon version 2.0.0+');
   }
-  $.Viewer.prototype.rotationBar = function(options){
+  $.Viewer.prototype.rotationBar = function(options) {
     options = options || {};
     options.viewer = this;
     this.rotateBar = new $.RotationBar(options);
-  }
-  $.RotationBar = function(options){
+  };
+  $.RotationBar = function(options) {
     options = options || {};
-    if(!options.viewer){
+    if (!options.viewer) {
       throw new Error('A viewer must be specified.');
     }
     this.viewer = options.viewer;
@@ -40,7 +40,7 @@
     this.idxR.classList.add('idxR');
     this.txtR = document.createElement('div');
     this.txtR.classList.add('txtR');
-    this.txtR.innerHTML = '0'
+    this.txtR.innerHTML = '0';
     this.degree = document.createElement('sup');
     this.degree.innerHTML = 'o';
     this.degree.style.marginLeft = '2px';
@@ -52,11 +52,11 @@
     const idk=this.txtR;
     const sup = this.degree;
     const view = this.viewer;
-    this.range.oninput = function(){
+    this.range.oninput = function() {
       idk.innerHTML = this.value;
       idk.appendChild(sup);
       var intValue = parseInt(this.value);
       view.viewport.setRotation(intValue);
-    }
-  }
-}(OpenSeadragon))
+    };
+  };
+}(OpenSeadragon));


### PR DESCRIPTION
This is an **initial implementation** of the rotation bar of OpenSeadragon instance.
![caMicroscope (1)](https://user-images.githubusercontent.com/48997514/79220542-cfbe9780-7e71-11ea-8651-94d639eff1aa.gif)
**Current Behaviour**
Currently rotation is enabled only if none of the tools ( measurement tool, draw annotations etc. ) are not selected.
Upon selecting any tool rotation is disabled and image angle is set to 0 degrees again.
This is done because there are issues with the tools when image is rotated.
Maybe we can open separate issues for resolving these problems.