### PR TITLE
Simplified sorting in slides page

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -522,11 +522,8 @@
 					//Adding names to later validate for new slide names
 					existingSlideNames = data.map(d => d[1]);
 
-					const thead = HeadMapping.map(d => "<th>" + d.title + `<img id='sort1${d.title}' class='float-right sort-btn' width='15px' src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAtklEQVRIie3XsQrCMBSF4T+CoJsddHAo9HH6AD634NbNqTgo6FI6WQdTtJLQpG0CxXsglIRyv0ugCYWZRsUGd8ARKIA0FroFTkCjxxnIYqNRcBsaFO9Dg+Cu6KS4LzoJrnh/Mr5oOwpgaSu+GNqVY6wHTN/Jo4DNz1oJrAzv7oH6a/4Ani7duabCvLVrnyKht1pggQUWWOA/g0vD2o3ulRgkOXDhcx1egYNvkTG/IIl+3nUD88gLIHVaGvUECUcAAAAASUVORK5CYII='/>
-
-					<img id='sort2${d.title}' class='float-right sort-btn' width='15px' src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAAs0lEQVRIie3VsQrCMBSF4T/qoFsddBR8Hncf24KTUAquDg4ugoPWwRbSEk2aJhHlHsiQhPCdZAl8KeMBZ+fADLgF6mLNBjgBVT3OwDYFXGqojqvY8NUAV7ye3Tmj8L0EFlhggQX+F3hi2VdAZlgzJQOm2vwCPDx7kWP+Al1G0SnSyqenVsDdt3Ed7xsvgD39b3sE1kMa++BB0L54UNQVj4La8KjoOzwJ2mQJ7IADsEqF/nae93FcRiryrh8AAAAASUVORK5CYII="/>
-					</th>`);
-
+					const thead = HeadMapping.map((d,i) => `<th>${d.title}	<span class="sort-btn fa fa-sort" data-order=${1}
+						 data-index=${i}>  </span> </th>`);
 
 					thead.push("<th></th>");
 
@@ -609,10 +606,9 @@
 					else
 						pageIndicatorVisible($("#datatables tbody .searched").length);
 				});
-				$(".sort-btn").on("click", function() {
-					var value = $(this)[0].id.substr(5);
-					var upordown = parseInt($(this)[0].id[4]);
-					var index = HeadMapping.findIndex((a)=> a.title.toLowerCase() == value.toLowerCase());
+				$(".sort-btn").on("click", function(e) {
+					var index = e.currentTarget.dataset.index;
+					var order = parseInt(e.currentTarget.dataset.order);
 
 					var trs = "#datatables tbody tr";
 					if(searching){
@@ -627,8 +623,9 @@
 							at=Number(at);
 							bt=Number(bt);
 						}
-						if(upordown===1)
+						if(order===1)
 						{
+							e.currentTarget.dataset.order = 2;
 							if(at>bt)
 								return 1;
 							else if(at<bt)
@@ -638,6 +635,7 @@
 						}
 						else
 						{
+							e.currentTarget.dataset.order = 1;
 							if (at < bt)
 								return 1;
 							else if (at > bt)


### PR DESCRIPTION
##  Description
The following changes have been made in sorting approach for slides page, to keep it a lot similar to that of the information-dashboard page 
- The 2 separate icons for up and down arrow are replaced by a single icon for sorting
- The information for index and order is stored in data-* attributes of the span tag, so as to simplify the code for sorting and making it more understandable 

## Motivation and Context
- Earlier, there were 2 separate icons for sorting which was not creating a good user experience
- The code for sorting earlier used to store the title in some part of the id, then extract it using substr() function and then match it with available headings to find out the index of the column, increasing the complexity and decreasing the readability of the code.  

## How Has This Been Tested?
- Tested in both Chrome and Firefox

## Screenshots:
![sort-slides](https://user-images.githubusercontent.com/45796806/79545861-03d2cc00-80af-11ea-84cb-1182d03b9d48.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
