### PR TITLE
Batch Loader Enhancement 

### DIFF
--- a/apps/batchloader/batchLoader.js
+++ b/apps/batchloader/batchLoader.js
@@ -11,6 +11,8 @@ let finishUrl = '../../loader/upload/finish/';
 let checkUrl = '../../loader/data/one/';
 let chunkSize = 5*1024*1024;
 let finishUploadSuccess = false;
+const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide'];
+
 
 $(document).ready(function() {
   $('#files').show(400);
@@ -193,6 +195,13 @@ function checkNames() {
         $('.fileNameEdit:eq('+i+')').parent().prepend(errorIcon);
       }
       numErrors++;
+    } else if (!allowedExtensions.includes(fileNames[i].substring(fileNames[i].lastIndexOf('.')+1,
+        fileNames[i].length))) {
+      let errorIcon = `<i id='fileNameError' class="fas fa-exclamation-circle text-danger" title='File extension not allowed'></i> &nbsp;&nbsp;`;
+      if ($('.fileNameEdit:eq('+i+')').prev().prev('#fileNameError').length == 0) {
+        $('.fileNameEdit:eq('+i+')').parent().prepend(errorIcon);
+      }
+      numErrors++;
     } else {
       $('.fileNameEdit:eq('+i+')').parent().find('#fileNameError').remove();
     }
@@ -284,7 +293,6 @@ function updateFileName(oldfileName) {
     let newFileName = $('#newFileName');
     let newName = newFileName.val();
     let fileExtension = newName.toLowerCase().split('.').reverse()[0];
-    const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide'];
 
     if (newName!='') {
       if (fileNames.includes(newName) || existingFiles.includes(newName)) {

--- a/apps/batchloader/batchloader.html
+++ b/apps/batchloader/batchloader.html
@@ -60,12 +60,17 @@
     </nav>
     <div style="align-content: center; padding-top: 2em;">
       <form onsubmit="return false;">
-        <div class="input-group mb-3" style="width: 25em; margin: 0 auto;">
+        <div
+          id="files"
+          class="input-group mb-3"
+          style="width: 25em; margin: 0 auto; display: none;"
+        >
           <div class="custom-file">
             <input
               type="file"
               class="custom-file-input"
               id="filesInput"
+              accept=".svs, .tif, .tiff, .vms, .vmu, .ndpi, .scn, .mrxs, .bif, .svslide"
               multiple
               required
             />
@@ -99,7 +104,7 @@
                 type="text"
                 id="fileNamesInput"
                 class="form-control"
-                placeholder="Enter general filename"
+                placeholder="filename (w/o extension)"
                 disabled
               />
             </div>
@@ -151,7 +156,7 @@
               class="btn btn-info"
               style="display: none;"
             >
-              Upload
+              <i class="fas fa-upload"></i> Upload
             </button>
             <button
               id="finish"

--- a/apps/batchloader/batchloader.html
+++ b/apps/batchloader/batchloader.html
@@ -17,11 +17,7 @@
     <script>
       __auth_check(2);
     </script>
-    <script
-      src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-      integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-      crossorigin="anonymous"
-    ></script>
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
       integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
@@ -202,11 +198,22 @@
     <div
       id="table"
       class="table-responsive-xl"
-      style="margin-top: 2em; display: none; text-align: center;"
+      style="
+        margin-top: 2em;
+        display: none;
+        text-align: center;
+        margin-bottom: 2em;
+      "
     >
       <table
         class="table table-hover"
-        style="width: 70em; margin: 0 auto; border-radius: 10px;"
+        style="
+          margin: 0 auto;
+          border-radius: 10px;
+          min-width: 50em;
+          max-width: 70em;
+          cursor: default;
+        "
       >
         <thead class="thead-light">
           <tr>
@@ -215,11 +222,134 @@
             <th scope="col">Slide</th>
             <th scope="col">Token</th>
             <th scope="col">Status</th>
+            <th scope="col"></th>
           </tr>
         </thead>
         <tbody></tbody>
       </table>
     </div>
+
+    <!--File Name change Modal -->
+    <div
+      class="modal fade"
+      id="fileNameChangeModal"
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="fileNameChangeModalLabel">
+              File name change
+            </h5>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <form onsubmit="return false">
+            <div class="modal-body" id="confirmUpdateFileContent"></div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                data-dismiss="modal"
+              >
+                Cancel
+              </button>
+              <button type="submit" id="confirmUpdateFile" class="btn btn-info">
+                Update
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <!--Slide Name change Modal -->
+    <div
+      class="modal fade"
+      id="slideNameChangeModal"
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="slideNameChangeModalLabel">
+              Slide name change
+            </h5>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <form onsubmit="return false">
+            <div class="modal-body" id="confirmUpdateSlideContent"></div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                data-dismiss="modal"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                id="confirmUpdateSlide"
+                class="btn btn-info"
+              >
+                Update
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <!--Slide Information Modal -->
+    <div
+      class="modal fade"
+      id="slideInfoModal"
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="slideInfoModalLabel">
+              Slide Information
+            </h5>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body" id="slideInfoContent"></div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-primary" data-dismiss="modal">
+              Okay
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script src="./batchLoader.js"></script>
   </body>
 </html>

--- a/apps/table.html
+++ b/apps/table.html
@@ -505,14 +505,14 @@
 							// console.log('reqId:' + slideDeleteRequests.find(o => o.slideDetails.slideId === rs[0])._id.$oid );
 							// console.log(rs[0]);
 							// console.log(typeof(rs[0]));
-							console.log(counter);
-							console.log(slideDeleteRequests);
+							// console.log(counter);
+							// console.log(slideDeleteRequests);
 							if (slideDeleteRequests['counter']) {
 								
 							console.log(slideDeleteRequests[counter]);
 							// console.log(slideDeleteRequests[counter - 1]);
 							}
-							console.log('Done one iter');
+							// console.log('Done one iter');
 
 							const btn = `<div id='open-delete'>
 									<button class="btn btn-success" data-id='${rs[0]}' onclick='openView(this)'>Open</button>

--- a/apps/table.html
+++ b/apps/table.html
@@ -199,9 +199,9 @@
 	<div class='p-2 bg-light' style="flex-grow: 1;">
 		<button type="button" class="btn btn-success float-right mb-2"
 			onclick="(()=>{location.reload();return false;})()"> <i class="fas fa-sync-alt"></i> Reload</button>
-			<div class="btn-group float-right mb-2 mr-2">
-				<button id="slideUploadButton" type="button" class="btn btn-primary " data-toggle="modal"
-			data-target="#upload-dialog" onclick="hidePostButton(); hideCheckButton(); resetUploadForm();" style="display: none;"> <i class="fas fa-upload"></i> Upload</button>
+			<div id="slideUploadButton" class="btn-group float-right mb-2 mr-2">
+				<button type="button" class="btn btn-primary " data-toggle="modal"
+			data-target="#upload-dialog" onclick="hidePostButton(); hideCheckButton(); resetUploadForm();" > <i class="fas fa-upload"></i> Upload</button>
 				<button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 				  <span class="sr-only">Toggle Dropdown</span>
 				</button>
@@ -780,6 +780,7 @@
 
 	//window.addEventListener('resize', ()=>{$('#datatables').stacktable()});
 	$(document).ready(function(){
+		$("#slideUploadButton").hide();
 		checkUserPermissions();
 		initialize();
 		$('#deleteModal').on('hidden.bs.modal', function (e) {
@@ -808,7 +809,7 @@
 			permissions = data;
 			// console.log(data);
 			if(permissions.slide.post == true)
-				$("#slideUploadButton").css("display","block");
+				$("#slideUploadButton").show();
 			if(permissions.slide.update == true){
 				$("#datatables").find("tr").each(function(){
 					var currentId = $("td:nth-child(1)", this).html();


### PR DESCRIPTION

## Description
Some features are added to the batch loader:
- Delete Functionality to remove the slide.
- Individual Slidename and FIlename change functionality.
- `Info` icon is added which to every row which on click describes various information about the slide like `original filename`, `filename` , `slide name`, `status`, `token` etc.
- Filename/slidename validation during individual edit.


## Motivation and Context
- Improving BatchLoader and working in reference to #352.


## How Has This Been Tested?
Tested on: 
- Mozilla 75.0, Chrome 81.0
- Ubuntu 19.10

## Screenshots:

![chrome-2020-04-20_09 13 27](https://user-images.githubusercontent.com/36575628/79712355-3c111f00-82e8-11ea-97c1-148340f0944d.gif)

![chrome-2020-04-20_09 09 13](https://user-images.githubusercontent.com/36575628/79712682-2e0fce00-82e9-11ea-88c3-81ccaf130ba9.gif)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
