### PR TITLE
Use backend to download and update download folder structure

### DIFF
--- a/apps/model/model.css
+++ b/apps/model/model.css
@@ -511,3 +511,63 @@ body{
   from {bottom: 30px; opacity: 1;}
   to {bottom: 0; opacity: 0;}
 }
+
+.switch1 {
+    position: relative;
+    display: inline-block;
+    width: 100px;
+    height: 26px;
+    border: 1px solid black;
+}
+
+.switch1 input {display:none;}
+
+.slider1 {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+.slider1:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: #365F9C;
+    -webkit-transition: .4s;
+    transition: .4s;
+}
+
+input:focus + .slider1 {
+    box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider1:before {
+    -webkit-transform: translateX(68px);
+    -ms-transform: translateX(26px);
+    transform: translateX(68px);
+}
+
+.slider1:after
+{
+    content:'NO';
+    position: absolute;
+    transform: translate(-50%,-50%);
+    top: 50%;
+    left: 54%;
+    font-size: 10px;
+    font-family: Verdana, sans-serif;
+}
+
+input:checked + .slider1:after
+{
+    content:'YES';
+    left: 35%;
+}

--- a/apps/model/model.js
+++ b/apps/model/model.js
@@ -1374,11 +1374,28 @@ async function extractRoi(choices, flag1) {
           const values =model.predict(batched).dataSync();
 
           results.push(values);
-          var maxIndex= results[0].reduce((a, b, i) => a[0] < b ? [b, i] : a, [Number.MIN_VALUE, -1]);
 
-          if (choices.classes.includes(classes[maxIndex[1]]) && ((maxIndex[0]*100)>choices.accuracy)) {
-            regions.push({state: 'true', acc: maxIndex[0], cls: classes[maxIndex[1]], X: x, Y: y});
+
+          var max = -1.0;
+          var ind = -1; ;
+
+          for (var i = 0; i < classes.length; i++) {
+            if (choices.classes.includes(classes[i]) && ((values[i]*100) > choices.accuracy)) {
+              if ( values[i] > max) {
+                ind = i;
+                max = values[i];
+              }
+            }
           }
+          if (ind != -1) {
+            regions.push({state: 'true', acc: values[ind], cls: classes[ind], X: x, Y: y});
+          }
+          // var maxIndex= results[0].reduce((a, b, i) => a[0] < b ? [b, i] : a, [Number.MIN_VALUE, -1]);
+          // console.log(maxIndex);
+          // for( var i = 0 ; i < )
+          // if (choices.classes.includes(classes[maxIndex[1]]) && ((maxIndex[0]*100)>choices.accuracy)) {
+          //   regions.push({state: 'true', acc: maxIndex[0], cls: classes[maxIndex[1]], X: x, Y: y});
+          // }
           //  else{
           //    regions.push({ state: 'false', acc: maxIndex[0], cls : classes[maxIndex[1]], X:x ,Y:y});
 
@@ -1403,10 +1420,11 @@ async function extractRoi(choices, flag1) {
     if (regions.length != 0) {
       // Use backend for extracting the patches
       if (choices.backend == true) {
-        var roiData = {predictions: '', slideid: '', filename: ''};
+        var roiData = {predictions: '', slideid: '', filename: '', patchsize: ''};
         roiData.predictions = regions;
         roiData.slideid = $D.params.slideId;
         roiData.filename = fileName;
+        roiData.patchsize = step;
         console.log(fileName);
         jsondata = JSON.stringify(roiData);
         console.log(jsondata);

--- a/apps/segment/segment.js
+++ b/apps/segment/segment.js
@@ -1483,6 +1483,9 @@ function downloadCSV(data, filename) {
   link.click();
 }
 
+/**
+ * Select model for extracting patches
+ */
 
 async function selectModel() {
   var data = await tf.io.listModels();
@@ -1531,6 +1534,11 @@ async function selectModel() {
   })($UI.roiModal.open());
 }
 
+/**
+ * Selct choices for extracting patches and masks
+ *
+ * @param name : name of the model selected
+ */
 
 async function selectChoices(name) {
   $UI.roiModal.close();
@@ -1538,26 +1546,6 @@ async function selectChoices(name) {
     selectedmodelName = name.split('/').pop().split('_').splice(2).join('_').slice(0, -3);
     var i;
     $('#choicedata').html('');
-    //   $('#choicedata').append(' <h4> Maximum area of contour :</h4>'+
-    // '<input type="range" min="0" max="5000" value="4500"  id = "maxArea"
-    // onchange="updateTextInput(this.value, maxinput.id)" />'+
-    // ' <input type="text" id="maxinput" class= "textInput" value="4500" /><br>');
-    //    $('#choicedata').append(' <h4> Minimum area of contour :</h4>'+
-    // '<input type="range" min="0" max="5000" value="0"  id = "minArea"
-    // onchange="updateTextInput(this.value , mininput.id)" />'+
-    // ' <input type="text" id="mininput" class= "textInput" value="0" /><br>');
-    //     $('#choicedata').append(' <h4> Threshold :</h4>'+
-    // '<input type="range" min="0" max="100" value="80"  id = "threshold1"
-    // onchange="updateTextInput(this.value , thresinput.id)" />'+
-    // ' <input type="text" id="thresinput" class= "textInput" value="80" /><br>');
-    //         $('#choicedata').append(' <h4> Opacity :</h4>'+
-    // '<input type="range" min="0" max="100" value="60"  id = "opacity1"
-    // onchange="updateTextInput(this.value , opacinput.id)" />'+
-    // ' <input type="text" id="opacinput" class= "textInput" value="60" /><br>');
-    //                  $('#choicedata').append(' <h4> Minimum number of objects :</h4>'+
-    // '<input type="range" min="0" max="100" value="0"  id = "minobj"
-    // onchange="updateTextInput(this.value , objinput.id)" />'+
-    // ' <input type="text" id="objinput" class= "textInput" value="0" /><br>');
     $('#choicedata').append(' <h4> Download options  :</h4>');
     $('#choicedata').append('<input type= "radio"  name = "choice" checked="checked" id= "both">'+
     '  Download both patches and masks</input><br><br>' +
@@ -1577,8 +1565,6 @@ async function selectChoices(name) {
       var choices = {model: '', dow: '', scale: 'norm'};
 
       choices.dow = $('input[name="choice"]:checked').val();
-      // choices.minObj  = document.getElementById('minobj').value;
-      // choices.opacity = document.getElementById('opacity1').value;
       choices.model = name;
       choices.scale = document.getElementById('scale_method').value;
       console.log(choices);
@@ -1589,8 +1575,6 @@ async function selectChoices(name) {
       var choices = {model: '', dow: '', scale: 'norm'};
 
       choices.dow = $('input[name="choice"]:checked').val();
-      // choices.minObj  = document.getElementById('minobj').value;
-      // choices.opacity = document.getElementById('opacity1').value;
       choices.model = name;
       choices.scale = document.getElementById('scale_method').value;
       console.log(choices);
@@ -1601,6 +1585,13 @@ async function selectChoices(name) {
     callback;
   })($UI.choiceModal.open());
 }
+
+/**
+ * Extract and download masks and patches
+ *
+ * @param choices : set of choices to download against
+ * @param flag1 : Indicator for using whole slide or portion of slide selected
+ */
 
 
 async function extractRoi(choices, flag1) {
@@ -1644,8 +1635,6 @@ async function extractRoi(choices, flag1) {
 
     fullResCvs.height = step;
     fullResCvs.width = step;
-    // const finalRes = document.querySelector('#mask');
-    // finalRes.getContext('2d').clearRect(0, 0, totalSize, totalSize);
     const temp = document.querySelector('#dummy');
     temp.height = step;
     temp.width = step;
@@ -1727,25 +1716,15 @@ async function extractRoi(choices, flag1) {
         });
 
         regionData.push({value: val, X: x, Y: y});
-        // tf.engine().startScope();
-        // await tf.browser.toPixels(val, temp);
-        // finalRes.getContext('2d').drawImage(temp, dx, dy);
-        // tf.engine().endScope();
         dx += step;
 
         c += 1;
-        console.log(c);
         $('#etap').html('');
         $('#etap').append('<b>' + (((c / totalPatches)) * 100).toFixed(0) + ' %</b> ');
       }
       dy += step;
     }
 
-    // console.log(regionData);
-    // fitCvs(finalRes);
-    // finalRes.style.opacity = 0.6;
-    // self.__opacity.value = 0.6;
-    // self.__oplabel.innerHTML = '0.6';
     self.hideProgress();
     model.dispose();
     var regionMask = [];
@@ -1753,21 +1732,13 @@ async function extractRoi(choices, flag1) {
       const temp = document.querySelector('#dummy');
       temp.height = step;
       temp.width = step;
-      // const finalRes = document.querySelector('#mask');
-      // finalRes.getContext('2d').clearRect(0, 0, step, step);
-
-
       tf.engine().startScope();
       await tf.browser.toPixels(regionData[i].value, temp);
-      // finalRes.getContext('2d').drawImage(temp, regionData[i].X, regionData[i].Y);
-      // fitCvs(finalRes);
       tf.engine().endScope();
       regionMask.push(temp.toDataURL().replace(/^data:image\/(png|jpg);base64,/, ''));
-
-      console.log(i);
     }
 
-    var zip = new JSZip();
+    var zip = new JSZip(); // zip file to download patches
     zip.folder('masks');
     var img = zip.folder('masks');
     document.getElementById('snackbar').className = '';
@@ -1775,7 +1746,6 @@ async function extractRoi(choices, flag1) {
     $('#snackbar').html('<h3> Downloading  Masks...</h3>' + '<span id = "etadm"></span>');
     document.getElementById('snackbar').className = 'show';
     for (var i = 0; i < regionMask.length; i++) {
-      console.log(i);
       img.file( i+ 'Mask' + '.png', regionMask[i], {base64: true});
 
       $('#etadm').html('');
@@ -1809,8 +1779,6 @@ async function extractRoi(choices, flag1) {
           c = c + 1;
           dx += step; $('#etadp').html('');
           $('#etadp').append('<b>' + (((c / regionMask.length)) * 100).toFixed(0) + ' % </b>');
-
-          console.log(c);
         }
         dy += step;
       }
@@ -1836,6 +1804,11 @@ async function extractRoi(choices, flag1) {
   };
 }
 
+/**
+ * Extract and download masks from selected region
+ *
+ * @param choices : set of choices to download against
+ */
 
 async function extractRoiSelect(choices) {
   choices1 = choices;
@@ -1844,10 +1817,5 @@ async function extractRoiSelect(choices) {
   $UI.choiceModal.close();
 
   drawRectangle({checked: true, state: 'roi', model: choices.model});
-}
-
-
-function updateTextInput(val, id) {
-  document.getElementById(id).value = val;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added feature to give user choice to use  SlideLoader to download the patches
- Updated the download folder structure so that now each class is downloaded in a separate folder with the class name

## Motivation and Context
- To make roi feature usable with large slide 
- In many places , datasets divided into folders according to their classes is used directly 

## How Has This Been Tested?
Ubuntu 20.04
Firefox 


## Types of changes
**What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
**Go over all the following points, and put an `x` in all the boxes that apply.
**(If you're unsure about any of these, don't hesitate to ask. We're here to help!)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


This depends on [SlideLoader #34 ](https://github.com/camicroscope/SlideLoader/pull/34)