### PR TITLE
Upload from Google Drive [Feature]

### DIFF
--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -3,6 +3,8 @@
 var startUrl = '../loader/upload/start';
 var continueUrl = '../loader/upload/continue/';
 var finishUrl = '../loader/upload/finish/';
+var startGoogleDriveUrl = '../loader/googleDriveUpload/getFile';
+var continueGoogleDriveUrl = '../loader/googleDriveUpload/checkStatus';
 var finishUploadSuccess = false;
 var checkSuccess = false;
 var chunkSize = 5*1024*1024;
@@ -250,4 +252,156 @@ async function continueUrlUpload(token, url) {
       alert(error['responseJSON']['error']);
     }
   });
+}
+
+function googlePickerStart() {
+  // The Browser API key obtained from the Google API Console.
+  // Replace with your own Browser API key, or your own key.
+  var developerKey = 'xxxx';
+
+  // The Client ID obtained from the Google API Console. Replace with your own Client ID.
+  var clientId = 'xxxx';
+
+  // Replace with your own project number from console.developers.google.com.
+  // See "Project number" under "IAM & Admin" > "Settings"
+  var appId = 'xxxx';
+
+  // Scope to use to access user's Drive items.
+  var scope = ['https://www.googleapis.com/auth/drive.file'];
+
+  var pickerApiLoaded = false;
+  var oauthToken;
+
+  // Use the Google API Loader script to load the google.picker script.
+  function loadPicker() {
+    gapi.load('auth', {'callback': onAuthApiLoad});
+    gapi.load('picker', {'callback': onPickerApiLoad});
+  }
+
+  function onAuthApiLoad() {
+    window.gapi.auth.authorize(
+        {
+          'client_id': clientId,
+          'scope': scope,
+          'immediate': false,
+        },
+        handleAuthResult);
+  }
+
+  function onPickerApiLoad() {
+    pickerApiLoaded = true;
+    createPicker();
+  }
+
+  function handleAuthResult(authResult) {
+    if (authResult && !authResult.error) {
+      oauthToken = authResult.access_token;
+      createPicker();
+    }
+  }
+
+  // Create and render a Picker object for searching images.
+  function createPicker() {
+    if (pickerApiLoaded && oauthToken) {
+      let view = new google.picker.DocsView(google.picker.ViewId.DOCS).setParent('root').setIncludeFolders(true);
+      let picker = new google.picker.PickerBuilder()
+          .enableFeature(google.picker.Feature.NAV_HIDDEN)
+          .setAppId(appId)
+          .setOAuthToken(oauthToken)
+          .addView(view)
+          .addView(new google.picker.DocsUploadView())
+          .setDeveloperKey(developerKey)
+          .setCallback(pickerCallback)
+          .build();
+      picker.setVisible(true);
+    }
+  }
+
+  // A simple callback implementation.
+  function pickerCallback(data) {
+    if (data.action == google.picker.Action.PICKED) {
+      let fileId = data.docs[0].id;
+      let fileName = data.docs[0].name;
+      // alert('The user selected: ' + fileId);
+      startGoogleDriveUpload(getUserId(), fileId, fileName);
+    }
+  }
+  loadPicker();
+  $('#upload-dialog').modal('hide');
+}
+
+
+function startGoogleDriveUpload(userId, fileId, fileName) {
+  $('#upload-dialog').modal('show');
+  $('.fileInputClass label').text(fileName);
+  $('#uploadLoading').show();
+  $('#gdriveUpload, #urlswitch').hide();
+  let data = JSON.stringify({'userId': userId, 'fileId': fileId});
+  console.log(data);
+  var requestOptions = {
+    method: 'POST',
+    body: data,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  };
+
+  fetch(startGoogleDriveUrl, requestOptions)
+      .then((response) => response.text())
+      .then((result) => {
+        result = JSON.parse(result);
+        console.log(result);
+        token = result['token'];
+        updateFormOnUpload(fileName, token);
+        $('#tokenRow').show(300);
+        if (result['authURL'] != null) {
+          window.open(result['authURL'], '_blank');
+        }
+        continueGoogleDriveUpload(token);
+      })
+      .catch((error) => console.log('error', error));
+}
+
+function continueGoogleDriveUpload(token) {
+  let data = JSON.stringify({'token': token});
+  var requestOptions = {
+    method: 'POST',
+    body: data,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  };
+  fetch(continueGoogleDriveUrl, requestOptions)
+      .then((response) => response.text())
+      .then((result) => {
+        result = JSON.parse(result);
+        console.log(result);
+      })
+      .catch((error) => console.log('error', error));
+
+  let i = 0;
+  let inter=setInterval(function() {
+    i++;
+    if (i>=180) { // 180*3000 ms = 9 minutes (max time for running this)
+      clearInterval(inter);
+    }
+    fetch(continueGoogleDriveUrl, requestOptions)
+        .then((response) => response.text())
+        .then((result) => {
+          result = JSON.parse(result);
+          console.log(result);
+          if (result['downloadDone']) {
+            changeStatus('UPLOAD', 'Done uploading file from google drive');
+            $('#filenameRow, #slidenameRow, #filterRow, #finish_btn').show(400);
+            $('#upload-progress-div, #uploadLoading').fadeOut();
+            $('#gdriveUpload, #urlswitch').show();
+            complete = true;
+            clearInterval(inter);
+          }
+        })
+        .catch((error) => {
+          console.log('error', error);
+          clearInterval(inter);
+        });
+  }, 3000);
 }

--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -254,17 +254,18 @@ async function continueUrlUpload(token, url) {
   });
 }
 
+// Start the Google Picker for Google Drive Upload
 function googlePickerStart() {
   // The Browser API key obtained from the Google API Console.
   // Replace with your own Browser API key, or your own key.
-  var developerKey = 'xxxx';
+  var developerKey = 'xxxxxx';
 
   // The Client ID obtained from the Google API Console. Replace with your own Client ID.
-  var clientId = 'xxxx';
+  var clientId = 'xxxxxx';
 
   // Replace with your own project number from console.developers.google.com.
   // See "Project number" under "IAM & Admin" > "Settings"
-  var appId = 'xxxx';
+  var appId = 'xxxxxx';
 
   // Scope to use to access user's Drive items.
   var scope = ['https://www.googleapis.com/auth/drive.file'];
@@ -300,7 +301,7 @@ function googlePickerStart() {
     }
   }
 
-  // Create and render a Picker object for searching images.
+  // Create and render a Picker object
   function createPicker() {
     if (pickerApiLoaded && oauthToken) {
       let view = new google.picker.DocsView(google.picker.ViewId.DOCS).setParent('root').setIncludeFolders(true);
@@ -337,8 +338,8 @@ function startGoogleDriveUpload(userId, fileId, fileName) {
   $('#uploadLoading').show();
   $('#gdriveUpload, #urlswitch').hide();
   let data = JSON.stringify({'userId': userId, 'fileId': fileId});
-  console.log(data);
-  var requestOptions = {
+  // console.log(data);
+  let requestOptions = {
     method: 'POST',
     body: data,
     headers: {
@@ -364,23 +365,16 @@ function startGoogleDriveUpload(userId, fileId, fileName) {
 
 function continueGoogleDriveUpload(token) {
   let data = JSON.stringify({'token': token});
-  var requestOptions = {
+  let requestOptions = {
     method: 'POST',
     body: data,
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
     },
   };
-  fetch(continueGoogleDriveUrl, requestOptions)
-      .then((response) => response.text())
-      .then((result) => {
-        result = JSON.parse(result);
-        console.log(result);
-      })
-      .catch((error) => console.log('error', error));
 
   let i = 0;
-  let inter=setInterval(function() {
+  let inter=setInterval(function() { // Calling this route every 3 sec. till the download is complete
     i++;
     if (i>=180) { // 180*3000 ms = 9 minutes (max time for running this)
       clearInterval(inter);
@@ -401,6 +395,7 @@ function continueGoogleDriveUpload(token) {
         })
         .catch((error) => {
           console.log('error', error);
+          alert('ERROR: '+error);
           clearInterval(inter);
         });
   }, 3000);

--- a/apps/table.html
+++ b/apps/table.html
@@ -24,6 +24,7 @@
 	<script src='../components/loading/loading.js'></script>
 	<script src="./loader/loader.js"></script>
 	<script src="./loader/chunked_upload.js"></script>
+	<script type="text/javascript" src="https://apis.google.com/js/api.js"></script>
 	<title>CaMicroscope Data Table</title>
 
 	<script src="https://code.jquery.com/jquery-3.4.1.min.js"
@@ -192,6 +193,7 @@
 													<div class="spinner-grow text-primary" role="status" style="margin-left: 1.2em;">
 														<span class="sr-only"></span>
 													</div> </div>
+													<a title="Upload from google drive" href="#" id='gdriveUpload' onclick="googlePickerStart()"><i style="font-size: 1.2em;" class="fab fa-google-drive"></i></a>
 													<a href="#" id='urlswitch' onclick="$('#urlInput').val(''); switchToUrl();" > <span style="position: absolute; right:2em;" > <i class="fas fa-link"></i> Upload from URL</span></a>
 													<a href="#" style="display: none;" id="fileswitch" onclick=" switchToFile();" > <span style="position: absolute; right:2em;" > <i class="fas fa-folder"></i> Upload from local</span></a>
 

--- a/docs/cloudUploadAPIs.md
+++ b/docs/cloudUploadAPIs.md
@@ -1,0 +1,37 @@
+# Cloud Upload APIs Guide
+
+
+## Google Picker API
+The picker API is to be used to allow user to select the file from their google drive.
+
+**Instructions:**
+ - Create a new project or go to your existing one at https://console.developers.google.com/ . Go to your project admin settings and note down your project number. (This will be your **`appId`**)
+ - Enable the picker api on your project.
+ - Go to the credentials page of your project, click on "Create Credentials > API Key"
+ - Note down your API key  (This will be your **`developerKey`**)<br>
+**Note**: Restrict your API key scopes to avoid unauthorised usage since this key will be public in the frontend.
+ -  Go to "OAuth Consent Screen" and create your consent screen
+- Select user type as External.
+- Proceed to add consent screen. Add your test users email.<br>
+**Note**: To allow users other than test users you need to verify your app with google first.
+ - Go to the credentials page of your project, click on "Create Credentials > OAuth Client ID"
+ - Select type as "Web Application". Then add `http://localhost:4010` to the list of authorised domains and redirect urls. Add other URLs if you have caMicroscope hosted on your own domain.
+ - Note down your ClientID.
+ - Now you have all your information needed for picker. Paste the details at `/apps/loader/chunked_loader.js` at caMicroscope in the shown place.
+ <br>![enter image description here](https://i.ibb.co/PhdTCyp/Screenshot-20201220-154455.jpg)
+
+Read more at https://developers.google.com/picker/docs/
+
+## Google Drive API
+
+Google drive API is to be used on Slideloader backend server to allow the download of file selected by user from the picker api earlier.
+
+**Instructions:**
+- Enable the Google Drive API on your project.
+-  Go to the credentials page of your project, click on "Create Credentials > OAuth Client ID"
+- Select type as "Desktop Application"
+- Download the JSON file for your OAuth 2.0 Client ID that you just created.
+- There's a dummy file present at `/cloud-upload-apis/credentials/google-drive.json` in the **[Distro](https://github.com/camicroscope/Distro)** ; Replace that file with the JSON file you downloaded in the previous step. <br> 
+**Note**: Do not rename the `google-drive.json` file
+
+Read more at https://developers.google.com/drive


### PR DESCRIPTION
This works with [SlideLoader #40](https://github.com/camicroscope/SlideLoader/pull/40) and [Distro #154](https://github.com/camicroscope/Distro/pull/154)

## Description
- An "**upload from google drive**" icon is provided during the upload process.
- Google Picker API is used to let user choose a file from their google drive storage.
- The picker api will extract the fileID from the chosen file and it'll be sent to Slideloader where Google Drive API will download the corresponding file directly on server-side saving user's time and data.
- The instructions for the API usage is described in `docs/cloudUploadAPIs.md`

## How Has This Been Tested?

- **Browser**: Firefox (v83), Chromium (v87)
- **OS**: Windows 10, Arch KDE (Linux-LTS)

## Screen-recording Demo :
**NOTE**:
- The authentication has to be done twice, once for picker api and another time for drive api. Once they are both done. User will not be prompted again for the same. 
- The app is shown as unverified because it's in testing phase. User can submit their app to google for verification and that message won't be shown anymore. 

https://user-images.githubusercontent.com/36575628/102714382-2a0ed280-42f4-11eb-953b-d66004498854.mp4



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.





