### PR TITLE
improve tour resume UX

### DIFF
--- a/apps/viewer/tut.js
+++ b/apps/viewer/tut.js
@@ -138,9 +138,9 @@ var tour = new Tour({
   '</div><div style=\'width:100%;display: flex;margin-bottom: 5px;\'>'+
   '<button class=\'btn btn-default\' data-role=\'end\' style=\'margin:auto;\'>End tour</button></div></div>',
   backdrop: true,
-  //resets tour always to resume always from the beginning
-  onEnd: function reset(){
-    window.localStorage.setItem('Tour_current_step',0);
-  }
+  // resets tour always to resume always from the beginning
+  onEnd: function reset() {
+    window.localStorage.setItem('Tour_current_step', 0);
+  },
 });
 tour.init();

--- a/apps/viewer/tut.js
+++ b/apps/viewer/tut.js
@@ -138,5 +138,9 @@ var tour = new Tour({
   '</div><div style=\'width:100%;display: flex;margin-bottom: 5px;\'>'+
   '<button class=\'btn btn-default\' data-role=\'end\' style=\'margin:auto;\'>End tour</button></div></div>',
   backdrop: true,
+  //resets tour always to resume always from the beginning
+  onEnd: function reset(){
+    window.localStorage.setItem('Tour_current_step',0);
+  }
 });
 tour.init();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Solves #481 
It is a UX improvement in tour.
What this change does?
- The tour that is provided for ease for users to understand if left in between, continues from where the user left i.e. default.
- But generally by UX perspective, the tour must start from the beginning because of the following problems:
  * If the tour is left at the end, it resumes from the end and doesn't again point to start.
  * If the user closes the window and when opens again, the local storage has stored the value of last left tour element. And thus will resume from there itself; which is unexpected for user as User would expect it to be from beginning only.

## How Has This Been Tested?
**Please describe in detail how you tested your changes.
- It changes `tut.js` file. It has been tested for its working on local set up.

## Types of changes
**What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
**Go over all the following points, and put an `x` in all the boxes that apply.
**(If you're unsure about any of these, don't hesitate to ask. We're here to help!)
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Please let me know how does this sounds. Would love to know your suggestions or improvements on this!