### PR TITLE
Add undo feature in Draw tool

### DIFF
--- a/components/simplecontextmenu/simplecontextmenu.css
+++ b/components/simplecontextmenu/simplecontextmenu.css
@@ -35,7 +35,9 @@ height:102px;
 
 .draw-menu-wrap .color,
 .draw-menu-wrap .style,
-.draw-menu-wrap .clear {
+.draw-menu-wrap .clear,
+.draw-menu-wrap .undo
+ {
   position:absolute;
   /* display:none; */
 }
@@ -45,16 +47,20 @@ height:102px;
   width:24px;
   height:24px;
 }
-
+.draw-menu-wrap .undo div {
+  width:24px;
+  height:24px;
+}
 /* style */
 .draw-menu-wrap .style {
   position:absolute;
 }
 
 
-.draw-menu-wrap .color, 
+.draw-menu-wrap .color,
 .draw-menu-wrap .clear,
-.draw-menu-wrap .style {
+.draw-menu-wrap .style,
+.draw-menu-wrap .undo {
   cursor: pointer;
   position: absolute;
   opacity: 0;
@@ -71,7 +77,8 @@ height:102px;
 
 .flag:checked ~ .color,
 .flag:checked ~ .clear,
-.flag:checked ~ .style  {
+.flag:checked ~ .style,
+.flag:checked ~ .undo  {
   opacity: 1;
 }
 /* list */
@@ -83,24 +90,31 @@ height:102px;
   transform: translateY(32px);
   transition-delay: .05s;
 }
+.flag:checked ~ .undo.list {
+  transform: translateY(58px);
+  transition-delay: .1s;
+}
 
 .flag:checked ~ .clear.list {
-  transform: translateY(58px);
+  transform: translateY(84px);
   transition-delay: .15s;
 }
 
 /* popup */
 .flag:checked ~ .style {
-  transform:translateX(-12px) translateY(-38px);
+  transform:translateX(-12px) translateY(-12px);
 }
 
 .flag:checked ~ .color {
   transform: translateX(12px) translateY(-12px);
   transition-delay: .05s;
 }
-
-.flag:checked ~ .clear {
+.flag:checked ~ .undo {
   transform: translateX(-12px) translateY(14px);
+  transition-delay: .1s;
+}
+.flag:checked ~ .clear {
+  transform: translateX(+12px) translateY(14px);
   transition-delay: .15s;
 }
 /* global focus */
@@ -118,7 +132,8 @@ height:102px;
 }
 .draw-menu-wrap .color,
 .draw-menu-wrap .clear,
-.draw-menu-wrap .style {
+.draw-menu-wrap .style,
+.draw-menu-wrap .undo  {
 
   border-radius: 5px;
  box-shadow: 0 .1rem .3rem 0 rgba(0,0,0,.3);
@@ -163,6 +178,3 @@ height:102px;
   display: block;
   text-align: center;
 }
-
-
-

--- a/components/simplecontextmenu/simplecontextmenu.js
+++ b/components/simplecontextmenu/simplecontextmenu.js
@@ -38,6 +38,12 @@
       this.raiseEvent('style-changed', this.getStyle());
     }.bind(this));
 
+    // undo event
+    const undo = this.elt.querySelector('.undo');
+    undo.addEventListener('click', function() {
+      this.raiseEvent('undo', {});
+    }.bind(this));
+
     // clear event
     const clear = this.elt.querySelector('.clear');
     clear.addEventListener('click', function() {
@@ -285,6 +291,19 @@
     clearIcon.textContent = 'layers_clear';
     clear.appendChild(clearIcon);
     elt.appendChild(clear);
+
+    // undo
+    const undo = document.createElement('div');
+    // clear.title = 'Clear';
+    undo.classList.add('undo');
+    undo.classList.add('item');
+
+    undoIcon = document.createElement('div');
+    undoIcon.classList.add('material-icons');
+    undoIcon.classList.add('icons');
+    undoIcon.textContent = 'undo';
+    undo.appendChild(undoIcon);
+    elt.appendChild(undo);
 
     // mode/draw-style
     const style = document.createElement('ul');

--- a/core/CaMic.js
+++ b/core/CaMic.js
@@ -254,9 +254,9 @@ class CaMic {
       this.viewer.canvasDrawInstance.drawMode = e.model;
     }.bind(this));
 
-    // this.drawContextmenu.addHandler('undo',function(e){
-    //   this.viewer.canvasDrawInstance.undo();
-    // }.bind(this));
+     this.drawContextmenu.addHandler('undo',function(e){
+       this.viewer.canvasDrawInstance.undo();
+     }.bind(this));
 
     // this.drawContextmenu.addHandler('redo',function(e){
     //   this.viewer.canvasDrawInstance.redo();


### PR DESCRIPTION
- Added undo feature to draw tool, works well for Draw-Infinity-mode. Added it in the simple-context-menu. I don't think it breaks anything

### Context
Previously only clear-all option was present, which required to erase all shapes to remove a single one. 
Code was already available in OpenSeadragon api

### How Has This Been Tested?
It works well, I could save the annotations 

### Screenshots:
![Screenshot (74)](https://user-images.githubusercontent.com/18577165/107798703-833e3400-6d82-11eb-8a09-a1eaa3f675a5.png)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) (Don't know)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
