### PR TITLE
[New Feature] Screenshot of Slide

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### caMicroscope [Unreleased](https://github.com/camicroscope/camicroscope/compare/v3.8.4...camicroscope:develop)
 ###### TBD
 * Auto convert png and jpg files via table load.
+* Addition of screenshot feature to the viewer [#496](https://github.com/camicroscope/caMicroscope/pull/496)
 
 ### caMicroscope [3.8.4](https://github.com/camicroscope/camicroscope/compare/v3.8.3...camicroscope:v3.8.4)
 ###### 2021-01-25

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The toolbar is in the top-left of the main content window. Use the toolbar butto
 | ![](https://fonts.gstatic.com/s/i/materialicons/get_app/v4/24px.svg)      | Download Slide      | Download the slide image to your system |
 | ![](https://fonts.gstatic.com/s/i/materialicons/playlist_add_check/v8/24px.svg)      | Mark Reviewed      | Use to signify the completion of review of a slide. |
 | ![](https://fonts.gstatic.com/s/i/materialicons/bug_report/v4/24px.svg)      | Bug Report      | Report a bug or give feedback. |
+| ![](https://fonts.gstatic.com/s/i/materialicons/camera_enhance/v4/24px.svg)      | Slide Capture      | Click to take a screenshot of the slide and annotations on it. |
 | ![](https://fonts.gstatic.com/s/i/materialicons/help/v4/24px.svg)      | Tutorial      | Click to view a guided tour of the viewer tools. |
 
 

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -480,6 +480,15 @@ async function initUIcomponents() {
       callback: updateSlideView,
     });
   }
+  // screenshot
+  subToolsOpt.push({
+    name: 'slideCapture',
+    icon: 'camera_enhance',
+    title: 'Slide Capture',
+    type: 'btn',
+    value: 'slCap',
+    callback: captureSlide,
+  });
   subToolsOpt.push({
     name: 'tutorial',
     icon: 'help',

--- a/apps/viewer/tut.js
+++ b/apps/viewer/tut.js
@@ -121,6 +121,13 @@ var tour = new Tour({
     smartPlacement: true,
   },
   {
+    element: 'i[title=\'Slide Capture\']',
+    title: 'Slide Capture',
+    content: 'Take Screenshot of the slide.',
+    placement: 'auto bottom',
+    smartPlacement: true,
+  },
+  {
     element: 'i[title=\'Tutorial\']',
     title: 'Tutorial',
     content: 'Click here to start viewer Tour.',

--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -2560,6 +2560,61 @@ async function rootCallback({root, parent, items}) {
   closeLoadStatus();
 }
 
+/* Slide Capture Tool */
+
+function captureSlide() {
+  toolsOff();
+  // console.log($CAMIC.viewer);
+  const slideCanvas = $CAMIC.viewer.canvas.firstChild;
+  if (!slideCanvas) {
+    console.warn('Incorrect Slide Canvas');
+    return;
+  }
+  const slideCtx = slideCanvas.getContext('2d');
+  const combiningCanvas = document.createElement('CANVAS');
+  combiningCanvas.height = window.innerHeight;
+  combiningCanvas.width = window.innerWidth;
+  const combiningCtx = combiningCanvas.getContext('2d');
+  const slideImageData = slideCanvas.toDataURL('image/png');
+  const slideImage = new Image();
+  slideImage.onload = function() {
+    combiningCtx.drawImage(slideImage, 0, 0, window.innerWidth, window.innerHeight);
+    const overlayCanvas = $CAMIC.viewer.omanager._display_;
+    if (overlayCanvas) {
+      combiningCtx.globalCompositeOperation = 'source-over';
+      const overlayCtx = overlayCanvas.getContext('2d');
+      const overlayImageData = overlayCanvas.toDataURL('image/png');
+      const overlayImage = new Image();
+      overlayImage.onload = function() {
+        combiningCtx.drawImage(overlayImage, 0, 0, window.innerWidth, window.innerHeight);
+        downloadSlideCapture(combiningCanvas);
+      };
+      overlayImage.src = overlayImageData;
+    } else {
+      console.warn('Incorrect Annotation Canvas');
+      downloadSlideCapture(combiningCanvas);
+    }
+  };
+  slideImage.src = slideImageData;
+}
+
+function downloadSlideCapture(combiningCanvas) {
+  const imageData = combiningCanvas.toDataURL('image/jpeg');
+  const downloadLink = document.createElement('a');
+  var imgFileName = prompt('Enter filename', 'slideCaptureShot');
+  if (imgFileName == null) {
+    ;
+  } else {
+    if (imgFileName === '') {
+      imgFileName = 'slideCapture';
+    }
+    imgFileName += '.jpeg';
+    downloadLink.download = imgFileName;
+    downloadLink.href = imageData;
+    downloadLink.click();
+  }
+}
+
 /* call back list END */
 /* --  -- */
 /* -- for render anno_data to canavs -- */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
**Describe your changes in detail

This screenshot feature helps user to take screenshot of the slide along with annotations and download it as an image.

## Motivation and Context
*Why is this change required? What problem does it solve?

This is useful as screenshots of slides are required by several users as they need to be included in reports or research papers.
Note :
This is the first and basic version of screen capture. Next step in this includes adding functionality to capture only a selected area of the slide.
This is the same PR as #493 

## How Has This Been Tested?
**Please describe in detail how you tested your changes.

I tested it on my local setup

## Screenshots (if appropriate):

![Untitled_ Feb 19, 2021 8_32 AM](https://user-images.githubusercontent.com/48997514/108451627-29ab9d00-728d-11eb-8fe6-44b6f5d9f179.gif)

## Types of changes
**What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
**Go over all the following points, and put an `x` in all the boxes that apply.
**(If you're unsure about any of these, don't hesitate to ask. We're here to help!)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
