### PR TITLE
Feature for additional links in toolbar

### DIFF
--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -570,28 +570,32 @@ async function initUIcomponents() {
   var additionalLinksFetchResponse = await fetch('http://localhost:4010/additional_links.json', {headers: headers});
   // Handle error
   if (!additionalLinksFetchResponse.ok) {
-    var message = `Error ${additionalLinksFetchResponse.status}: File not found or file not in correct format`;
-    alert(message);
-    throw new Error(message);
+    var message = `Error ${additionalLinksFetchResponse.status}: File containing JSON data for additional links not found`;
+    console.error(message);
+  } else {
+    try {
+      var additionalLinks = await additionalLinksFetchResponse.json();
+  
+      additionalLinks.forEach(function(additionalLink) {
+        var openInNewTab = additionalLink.openInNewTab === false ? false : true;
+        var url = additionalLink.url;
+    
+        subToolsOpt.push({
+          name: additionalLink.displayName,
+          icon: additionalLink.icon ? additionalLink.icon : 'link',
+          title: additionalLink.displayName,
+          value: additionalLink.displayName,
+          type: 'btn',
+          callback: function() {
+            additionalLinksHandler(url, openInNewTab);
+          },
+        });
+      });
+    } catch (error) {
+      console.error(error);
+    }
   }
 
-  var additionalLinks = await additionalLinksFetchResponse.json();
-
-  additionalLinks.forEach(function(additionalLink) {
-    var openInNewTab = additionalLink.openInNewTab === false ? false : true;
-    var url = additionalLink.url;
-
-    subToolsOpt.push({
-      name: additionalLink.displayName,
-      icon: additionalLink.icon ? additionalLink.icon : 'link',
-      title: additionalLink.displayName,
-      value: additionalLink.displayName,
-      type: 'btn',
-      callback: function() {
-        additionalLinksHandler(url, openInNewTab);
-      },
-    });
-  });
 
   // create the tool bar
   $UI.toolbar = new CaToolbar({

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -553,6 +553,39 @@ async function initUIcomponents() {
       tour.start(true);
     },
   });
+
+  // Additional Links handler
+  var headers = {
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  function additionalLinksHandler(url, openInNewTab) {
+    if (openInNewTab === true) {
+      window.open(url, '_blank').focus();
+    } else {
+      window.location.href = url;
+    }
+  }
+
+  var additionalLinksFetchResponse = await fetch('http://localhost:4010/additional_links.json', {headers: headers});
+  var additionalLinks = await additionalLinksFetchResponse.json();
+
+  additionalLinks.forEach(function(additionalLink) {
+    var openInNewTab = additionalLink.openInNewTab === false ? false : true;
+    var url = additionalLink.url;
+
+    subToolsOpt.push({
+      name: additionalLink.displayName,
+      icon: additionalLink.icon ? additionalLink.icon : 'link',
+      title: additionalLink.displayName,
+      value: additionalLink.displayName,
+      type: 'btn',
+      callback: function() {
+        additionalLinksHandler(url, openInNewTab);
+      },
+    });
+  });
+
   // create the tool bar
   $UI.toolbar = new CaToolbar({
     /* opts that need to think of*/

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -568,6 +568,13 @@ async function initUIcomponents() {
   }
 
   var additionalLinksFetchResponse = await fetch('http://localhost:4010/additional_links.json', {headers: headers});
+  // Handle error
+  if (!additionalLinksFetchResponse.ok) {
+    var message = `Error ${additionalLinksFetchResponse.status}: File not found or file not in correct format`;
+    alert(message);
+    throw new Error(message);
+  }
+
   var additionalLinks = await additionalLinksFetchResponse.json();
 
   additionalLinks.forEach(function(additionalLink) {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title -->
Feature for additional links in toolbar of viewer.

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
This change provides the ability to put additional links in the toolbar for the slide viewer. This PR should solve #468 . This feature also needs a JSON file which is described in [Distro PR-161](https://github.com/camicroscope/Distro/pull/161).

![InkedVirtualBox_Ubuntu-18-GSOC_01_04_2021_17_45_12_crop_LI](https://user-images.githubusercontent.com/35070972/113293546-8af66f80-9313-11eb-9198-0913fba81367.jpg)
The new links are appended as shown with the green marker.
The links are customizable with the following parameters:
1. The URL
2. The name to be displayed
3. The icon to be displayed (material icons)
4. A boolean to choose if the link is to be opened in new tab, or in current tab.

## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->
Yes it fixes #468 

## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->
This has been tested on local system running Ubuntu 18.04, docker-compose version 1.28.6, and Mozilla firefox browser.

## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
