### PR TITLE
Now, JPG images can be uploaded using batch loader

### DIFF
--- a/apps/batchloader/batchLoader.js
+++ b/apps/batchloader/batchLoader.js
@@ -295,7 +295,7 @@ function updateFileName(oldfileName) {
     let newFileName = $('#newFileName');
     let newName = newFileName.val();
     let fileExtension = newName.toLowerCase().split('.').reverse()[0];
-    alert(fileExtension);
+  
     if (newName!='') {
       if (fileNames.includes(newName) || existingFiles.includes(newName)) {
         newFileName.addClass('is-invalid');

--- a/apps/batchloader/batchLoader.js
+++ b/apps/batchloader/batchLoader.js
@@ -11,7 +11,7 @@ let finishUrl = '../../loader/upload/finish/';
 let checkUrl = '../../loader/data/one/';
 let chunkSize = 5*1024*1024;
 let finishUploadSuccess = false;
-const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide'];
+const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide' , 'JPG' ,'jpg' , 'jpeg', 'png'];
 
 
 $(document).ready(function() {
@@ -90,6 +90,7 @@ function addbody(rowData) {
 }
 
 function startTable() {
+
   slideNames = [];
   fileNames = [];
   originalFileNames = [];
@@ -281,6 +282,7 @@ function updateFileName(oldfileName) {
   $('#confirmUpdateFileContent').html('Enter the new name for: <br><b>'+oldfileName+
          '</b><br><br><div class="form-group"><input type="text" id="newFileName" class="form-control"'+
          ' value="'+oldfileName+'" aria-label="newFileName" required></div>');
+  
   let input = document.getElementById('newFileName');
   let value = input.value;
   input.setSelectionRange(0, value.lastIndexOf('.'));
@@ -293,7 +295,7 @@ function updateFileName(oldfileName) {
     let newFileName = $('#newFileName');
     let newName = newFileName.val();
     let fileExtension = newName.toLowerCase().split('.').reverse()[0];
-
+    alert(fileExtension);
     if (newName!='') {
       if (fileNames.includes(newName) || existingFiles.includes(newName)) {
         newFileName.addClass('is-invalid');
@@ -303,7 +305,8 @@ function updateFileName(oldfileName) {
         } else {
           $('#filename-feedback0').html(`File with given name already exists`);
         }
-      } else if (!allowedExtensions.includes(fileExtension)) {
+      } else if (!allowedExtensions.includes(fileExtension.toLowerCase())) {
+        // console.log(fileExtension);
         newFileName.addClass('is-invalid');
         if (newFileName.parent().children().length === 1) {
           newFileName.parent().append(`<div class="invalid-feedback" id="filename-feedback0"> 

--- a/apps/batchloader/batchloader.html
+++ b/apps/batchloader/batchloader.html
@@ -70,7 +70,7 @@
               type="file"
               class="custom-file-input"
               id="filesInput"
-              accept=".svs, .tif, .tiff, .vms, .vmu, .ndpi, .scn, .mrxs, .bif, .svslide"
+              accept=".svs, .tif, .tiff, .vms, .vmu, .ndpi, .scn, .mrxs, .bif, .svslide , .jpg , .jpeg , .png"
               multiple
               required
             />


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Title -->

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
In the previous version of the software, the user is not allowed to upload the images of jpg, jpeg, or png format.

But in many cases, the images to be visualized might be in the jpg format. It is a painful job to convert all the jpg image data to pyramidal tiff format, then upload and visualize. It would be easy for the user if we allow uploading of jpg images also.


## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->

the issue(regarding the uploading of JPG images) is reported as issue number: #458 
## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->

## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
