### PR TITLE
Support for including Measurements in the ScreenShot added

### DIFF
--- a/common/util.js
+++ b/common/util.js
@@ -1074,10 +1074,10 @@ async function captureScreen(camic, {
 
           // details about position and size of ruler div
           const rulerDiv = {
-            left : parseFloat(availableRulers[i].style.left),
-            top : parseFloat(availableRulers[i].style.top),
-            width : parseFloat(availableRulers[i].style.width),
-            height : parseFloat(availableRulers[i].style.height),
+            left : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('left')),
+            top : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('top')),
+            width : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('width')),
+            height : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('height')),
             direction : null
           }
           // skip iteration if Ruler Div has some missing attributes

--- a/common/util.js
+++ b/common/util.js
@@ -1072,14 +1072,36 @@ async function captureScreen(camic, {
         // add to canvas only if ruler is visible on the slide
         if(availableRulers[i].style.display !== 'none') {
 
+          // let overlay = viewer.getOverlayById(availableRulers[i]);
+          // //console.log(overlay);
+          // let overlayBounds = viewer.viewport.viewportToViewerElementRectangle(overlay.getBounds(viewer.viewport));
+          // //console.log(overlayBounds);
+
+
           // details about position and size of ruler div
+          // const rulerDiv = {
+          //   left : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('left')),
+          //   top : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('top')),
+          //   width : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('width')),
+          //   height : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('height')),
+          //   direction : null
+          // }
           const rulerDiv = {
-            left : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('left')),
-            top : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('top')),
-            width : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('width')),
-            height : parseFloat(window.getComputedStyle(availableRulers[i], null).getPropertyValue('height')),
+            left : parseFloat(availableRulers[i].style.left)*(slideCanvas.width/window.innerWidth),
+            top : parseFloat(availableRulers[i].style.top)*(slideCanvas.height/window.innerHeight),
+            width : parseFloat(availableRulers[i].style.width)*(slideCanvas.width/window.innerWidth),
+            height : parseFloat(availableRulers[i].style.height)*(slideCanvas.height/window.innerHeight),
             direction : null
           }
+          // console.log(slideCanvas);
+          // console.log(canvas);
+          // console.log(rulerDiv);
+          // const rulerDiv ={
+          //   left : overlayBounds.x,
+          //   top : overlayBounds.y,
+          //   width : overlayBounds.width,
+          //   height : overlayBounds.height
+          // }
           // skip iteration if Ruler Div has some missing attributes
           if(isNaN(rulerDiv.left) || isNaN(rulerDiv.top) || isNaN(rulerDiv.width) || isNaN(rulerDiv.height)) {
             console.error('Required Attributes of Ruler Missing');
@@ -1112,7 +1134,7 @@ async function captureScreen(camic, {
             }
             // drawing ruler on result canvas
             ctx.strokeStyle = '#acfc03e6';
-            ctx.lineWidth = 2;
+            ctx.lineWidth = 2* ((slideCanvas.width) / (window.innerWidth));
             ctx.beginPath();
             if(rulerDiv.direction === 'l2r') {
               ctx.moveTo(rulerDiv.left, rulerDiv.top);
@@ -1128,7 +1150,7 @@ async function captureScreen(camic, {
             
             // writing ruler Value on result canvas
             let scaleValue = '';
-            let fontSize = 13;
+            let fontSize = 13 * ((slideCanvas.width) / (window.innerWidth));
             for(let j = 0; j < availableRulers[i].children.length; j++){
               if(availableRulers[i].children[j].className === 'box'){
                 try{
@@ -1145,7 +1167,7 @@ async function captureScreen(camic, {
             ctx.fillStyle = '#acfc03e6';
             let xOffset = (rulerDiv.width/2 + rulerDiv.left);
             let yOffset = (rulerDiv.height/2 + rulerDiv.top);
-            ctx.fillRect(xOffset - ctx.measureText(scaleValue).width/2, yOffset - fontSize + 2, ctx.measureText(scaleValue).width, fontSize);
+            ctx.fillRect(xOffset - ctx.measureText(scaleValue).width/2, yOffset - fontSize + (2 * ((slideCanvas.width) / (window.innerWidth))), ctx.measureText(scaleValue).width, fontSize);
 
             // scale value text
             ctx.fillStyle = 'black';
@@ -1156,7 +1178,7 @@ async function captureScreen(camic, {
             // for ruler mode coordinate
             // drawing coordinate ruler on result canvas
             ctx.strokeStyle = '#acfc03e6';
-            ctx.lineWidth = 2;
+            ctx.lineWidth = 2 * ((slideCanvas.width) / (window.innerWidth));
             ctx.beginPath();
             ctx.moveTo(rulerDiv.left, rulerDiv.top);
             ctx.lineTo(rulerDiv.left, rulerDiv.height + rulerDiv.top);
@@ -1184,18 +1206,19 @@ async function captureScreen(camic, {
                 }
               }
             }
-
-            let fontSize = 13;
+            console.log(h_scaleValue);
+            console.log(v_scaleValue);
+            let fontSize = 13 * ((slideCanvas.width) / (window.innerWidth));
             
-            let h_xOffset = (rulerDiv.left);
-            let h_yOffset = (rulerDiv.height/2 + rulerDiv.top);
-            let v_xOffset = (rulerDiv.width/2 + rulerDiv.left);
-            let v_yOffset = (rulerDiv.height + rulerDiv.top) + 11;
+            let v_xOffset = (rulerDiv.left);
+            let v_yOffset = (rulerDiv.height/2 + rulerDiv.top);
+            let h_xOffset = (rulerDiv.width/2 + rulerDiv.left);
+            let h_yOffset = (rulerDiv.height + rulerDiv.top) + (11 * ((slideCanvas.width) / (window.innerWidth)));
 
              // background behind scale value
             ctx.font = `900 ${fontSize}px sans-serif`;
             ctx.fillStyle = '#acfc03e6';
-            ctx.fillRect(h_xOffset - ctx.measureText(h_scaleValue).width/2, h_yOffset - fontSize + 2, ctx.measureText(h_scaleValue).width, fontSize);
+            ctx.fillRect(h_xOffset - ctx.measureText(h_scaleValue).width/2, h_yOffset - fontSize + (2 * ((slideCanvas.width) / (window.innerWidth))), ctx.measureText(h_scaleValue).width, fontSize);
 
             // scale value text
             ctx.fillStyle = 'black';
@@ -1205,7 +1228,7 @@ async function captureScreen(camic, {
              // background behind scale value
             ctx.font = `900 ${fontSize}px sans-serif`;
             ctx.fillStyle = '#acfc03e6';
-            ctx.fillRect(v_xOffset - ctx.measureText(v_scaleValue).width/2, v_yOffset - fontSize + 2, ctx.measureText(v_scaleValue).width , fontSize);
+            ctx.fillRect(v_xOffset - ctx.measureText(v_scaleValue).width/2, v_yOffset - fontSize + (2 * ((slideCanvas.width) / (window.innerWidth))), ctx.measureText(v_scaleValue).width , fontSize);
 
             // scale value text
             ctx.fillStyle = 'black';

--- a/common/util.js
+++ b/common/util.js
@@ -1062,6 +1062,161 @@ async function captureScreen(camic, {
   }
   */
 
+  if(hasRuler &&
+    viewer.measureInstance
+    ) {
+      // get HTML elements of all ruler divs
+      const availableRulers = document.getElementsByClassName('ruler');
+
+      for(let i = 0; i < availableRulers.length; i++) {
+        // add to canvas only if ruler is visible on the slide
+        if(availableRulers[i].style.display !== 'none') {
+
+          // details about position and size of ruler div
+          const rulerDiv = {
+            left : parseFloat(availableRulers[i].style.left),
+            top : parseFloat(availableRulers[i].style.top),
+            width : parseFloat(availableRulers[i].style.width),
+            height : parseFloat(availableRulers[i].style.height),
+            direction : null
+          }
+          // skip iteration if Ruler Div has some missing attributes
+          if(isNaN(rulerDiv.left) || isNaN(rulerDiv.top) || isNaN(rulerDiv.width) || isNaN(rulerDiv.height)) {
+            console.error('Required Attributes of Ruler Missing');
+            continue;
+          }
+          // for ruler mode straight
+          if(availableRulers[i].dataset.mode === 'straight') {
+
+            // checking direction of ruler in this mode
+            for(let j = 0; j < availableRulers[i].children.length; j++) {
+
+              if(availableRulers[i].children[j].className === 'scale h') {
+                let rotateIndex = availableRulers[i].children[j].style.transform.search('rotate');
+                let len = availableRulers[i].children[j].style.transform.length;
+                let rotateAngle;
+                if(rotateIndex != -1) {
+                  rotateAngle = parseFloat(availableRulers[i].children[j].style.transform.substring(rotateIndex + 7, len));
+                }
+                if(isNaN(rotateAngle)){
+                  rotateAngle = (Math.PI);
+                }
+                if(rotateAngle >= (Math.PI / 2)) {
+                  rulerDiv.direction = 'r2l';
+                } else{
+                  rulerDiv.direction = 'l2r';
+                }
+                break;
+              }
+
+            }
+            // drawing ruler on result canvas
+            ctx.strokeStyle = '#acfc03e6';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            if(rulerDiv.direction === 'l2r') {
+              ctx.moveTo(rulerDiv.left, rulerDiv.top);
+              ctx.lineTo(rulerDiv.width + rulerDiv.left, rulerDiv.height + rulerDiv.top);
+            } else if(rulerDiv.direction === 'r2l') {
+              ctx.moveTo(rulerDiv.width + rulerDiv.left, rulerDiv.top);
+              ctx.lineTo(rulerDiv.left, rulerDiv.height + rulerDiv.top);
+            } else {
+              console.error('Something went wrong');
+              continue;
+            }           
+            ctx.stroke();
+            
+            // writing ruler Value on result canvas
+            let scaleValue = '';
+            let fontSize = 13;
+            for(let j = 0; j < availableRulers[i].children.length; j++){
+              if(availableRulers[i].children[j].className === 'box'){
+                try{
+                  scaleValue = availableRulers[i].children[j].children[0].innerHTML;
+                }
+                catch(error){
+                  scaleValue = '';
+                }
+                break;
+              }
+            }
+            // background behind scale value
+            ctx.font = `900 ${fontSize}px sans-serif`;
+            ctx.fillStyle = '#acfc03e6';
+            let xOffset = (rulerDiv.width/2 + rulerDiv.left);
+            let yOffset = (rulerDiv.height/2 + rulerDiv.top);
+            ctx.fillRect(xOffset - ctx.measureText(scaleValue).width/2, yOffset - fontSize + 2, ctx.measureText(scaleValue).width, fontSize);
+
+            // scale value text
+            ctx.fillStyle = 'black';
+            ctx.textAlign = 'center';
+            ctx.fillText(scaleValue, xOffset , yOffset);
+
+          } else {
+            // for ruler mode coordinate
+            // drawing coordinate ruler on result canvas
+            ctx.strokeStyle = '#acfc03e6';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(rulerDiv.left, rulerDiv.top);
+            ctx.lineTo(rulerDiv.left, rulerDiv.height + rulerDiv.top);
+            ctx.moveTo(rulerDiv.left, rulerDiv.height + rulerDiv.top);
+            ctx.lineTo(rulerDiv.left + rulerDiv.width, rulerDiv.height + rulerDiv.top);
+            ctx.stroke();
+
+            let h_scaleValue = '';
+            let v_scaleValue = '';
+
+            for(let j = 0; j < availableRulers[i].children.length; j++){
+              if(availableRulers[i].children[j].className === 'h_scale'){
+                try{
+                  h_scaleValue = availableRulers[i].children[j].children[0].innerHTML;
+                }
+                catch(error){
+                  h_scaleValue = '';
+                }
+              } else if(availableRulers[i].children[j].className === 'v_scale'){
+                try{
+                  v_scaleValue = availableRulers[i].children[j].children[0].innerHTML;
+                }
+                catch(error){
+                  v_scaleValue = '';
+                }
+              }
+            }
+
+            let fontSize = 13;
+            
+            let h_xOffset = (rulerDiv.left);
+            let h_yOffset = (rulerDiv.height/2 + rulerDiv.top);
+            let v_xOffset = (rulerDiv.width/2 + rulerDiv.left);
+            let v_yOffset = (rulerDiv.height + rulerDiv.top) + 11;
+
+             // background behind scale value
+            ctx.font = `900 ${fontSize}px sans-serif`;
+            ctx.fillStyle = '#acfc03e6';
+            ctx.fillRect(h_xOffset - ctx.measureText(h_scaleValue).width/2, h_yOffset - fontSize + 2, ctx.measureText(h_scaleValue).width, fontSize);
+
+            // scale value text
+            ctx.fillStyle = 'black';
+            ctx.textAlign = 'center';
+            ctx.fillText(h_scaleValue, h_xOffset , h_yOffset);
+
+             // background behind scale value
+            ctx.font = `900 ${fontSize}px sans-serif`;
+            ctx.fillStyle = '#acfc03e6';
+            ctx.fillRect(v_xOffset - ctx.measureText(v_scaleValue).width/2, v_yOffset - fontSize + 2, ctx.measureText(v_scaleValue).width , fontSize);
+
+            // scale value text
+            ctx.fillStyle = 'black';
+            ctx.textAlign = 'center';
+            ctx.fillText(v_scaleValue, v_xOffset , v_yOffset);
+
+          }          
+        }
+      }
+  }
+
   return canvas;
 
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title -->

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
In this Pull Request I have added support for including rulers in the Screenshot feature as well. This is in continuation to the pull request #496 
## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->
Currently, rulers are not included in the screenshot. I implemented it without using any eternal library thus, not affecting the performance much.
## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->
I have attached the screenshot of the working of the feature
![Untitled_ Apr 14, 2021 7_50 PM](https://user-images.githubusercontent.com/48997514/114726491-1122a500-9d5b-11eb-9343-08add44afd40.gif)

## Questions
<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
