### PR TITLE
Include segmentation as annotations

### DIFF
--- a/apps/segment/segment.html
+++ b/apps/segment/segment.html
@@ -135,6 +135,7 @@
   <script type='text/javascript' src='../../core/Store.js'></script>
   <script type='text/javascript' src='../../core/CaMic.js'></script>
 
+  <script type='text/javascript' src='../../core/extension/segment-annotation.js'></script>
   <script type='text/javascript' src='../../core/extension/openseadragon-canvas-draw-overlay.js'></script>
   <script type='text/javascript' src='../../core/extension/openseadragon-overlays-manage.js'></script>
   <script type='text/javascript' src='../../core/extension/openseadragon-measurement-tool/openseadragon-measurement-tool.js'></script>

--- a/apps/segment/segment.js
+++ b/apps/segment/segment.js
@@ -356,7 +356,7 @@ function initCore() {
     slideQuery.name = $D.params.slide;
     slideQuery.location = $D.params.location;
     $CAMIC = new CaMic('main_viewer', slideQuery, opt);
-    anno = new segmentationanno($CAMIC,$D,$UI,slideQuery.id);
+    anno = new segmentationanno($CAMIC, $D, $UI, slideQuery.id);
   } catch (error) {
     Loading.close();
     $UI.message.addError('Core Initialization Failed');
@@ -571,32 +571,34 @@ function camicStopDraw(e) {
   }
 }
 
-function saveAnnotation(){
-  let notes = {name:$UI.segmentPanel.__name.value, notes:$UI.segmentPanel.__notes.value};
+function saveAnnotation() {
+  let notes = {name: $UI.segmentPanel.__name.value, notes: $UI.segmentPanel.__notes.value};
   let canv = !$UI.args||$UI.args.status == 'watershed'? $UI.segmentPanel.__out: $UI.segmentPanel.__mask;
-  //let image = canv.getContext('2d').getImageData(0,0,canv.width,canv.height);
-  const canvasDraw = $CAMIC.viewer.canvasDrawInstance, viewer = $CAMIC.viewer;
+  // let image = canv.getContext('2d').getImageData(0,0,canv.width,canv.height);
+  const canvasDraw = $CAMIC.viewer.canvasDrawInstance; const viewer = $CAMIC.viewer;
 
   canvasDraw.clear();
   canvasDraw._simplify = false;
-  if($UI.args && $UI.args.status != 'watershed')
-    findContour(canv,canv,0.11);
+  if ($UI.args && $UI.args.status != 'watershed') {
+    findContour(canv, canv, 0.11);
+  }
   let data = $UI.segmentPanel.__contours;
   const vpx = $UI.segmentPanel.__top_left[0];
   const vpy = $UI.segmentPanel.__top_left[1];
   $UI.segmentPanel.close();
-  //let te = {data:Array.from(image.data),width:image.width,height:image.height,x:vpx,y:vpy};
-  for(var i=0;i<data.length;i++){
+  // let te = {data:Array.from(image.data),width:image.width,height:image.height,x:vpx,y:vpy};
+  for (var i=0; i<data.length; i++) {
     var d = data[i].data32S;
     var arr=[];
-    for(var j = 0; j<d.length-1;j+=2){
-      arr.push([d[j] + vpx , d[j+1] + vpy]);}
-    canvasDraw._redraw(arr,'Polygon');
+    for (var j = 0; j<d.length-1; j+=2) {
+      arr.push([d[j] + vpx, d[j+1] + vpy]);
+    }
+    canvasDraw._redraw(arr, 'Polygon');
   }
   let temp = canvasDraw.getImageFeatureCollection();
   canvasDraw.clear();
   canvasDraw._simplify = true;
-  anno.saveSegment(null,temp,notes);
+  anno.saveSegment(null, temp, notes);
 }
 
 function checkSize(imgColl, imagingHelper) {
@@ -1044,7 +1046,7 @@ function segmentROI(box) {
   console.log(f);
   */
 }
-function findContour(inn,out,thresh){
+function findContour(inn, out, thresh) {
   let src = cv.imread(inn);
   let dst = cv.Mat.zeros(src.cols, src.rows, cv.CV_8UC3);
   cv.cvtColor(src, src, cv.COLOR_RGBA2GRAY, 0);
@@ -1135,7 +1137,7 @@ function watershed(inn, out, save=null, thresh) {
 
   // Find the stuff that IS an object
   cv.dilate(gray, opening, M); // remove any small white noises in the image
-  //cv.dilate(opening, imageBg, M, new cv.Point(-1, -1), 3); // remove any small holes in the object
+  // cv.dilate(opening, imageBg, M, new cv.Point(-1, -1), 3); // remove any small holes in the object
 
   // Distance transform - for the stuff we're not sure about
   cv.distanceTransform(opening, distTrans, cv.DIST_L2, 5);
@@ -1147,10 +1149,10 @@ function watershed(inn, out, save=null, thresh) {
 
   // Mark (label) the regions starting with 1 (color output)
   imageFg.convertTo(imageFg, cv.CV_8U, 1, 0);
-  //cv.subtract(imageBg, imageFg, unknown);
+  // cv.subtract(imageBg, imageFg, unknown);
 
   // Get connected components markers
-  //const x = cv.connectedComponents(imageFg, markers);
+  // const x = cv.connectedComponents(imageFg, markers);
 
   // Get Polygons
   const contours = new cv.MatVector();
@@ -1160,16 +1162,16 @@ function watershed(inn, out, save=null, thresh) {
   $UI.segmentPanel.__contours = contours;
   console.log('Getting contours.');
 
-  //for (let i = 0; i < markers.rows; i++) {
+  // for (let i = 0; i < markers.rows; i++) {
   //  for (let j = 0; j < markers.cols; j++) {
   //    markers.intPtr(i, j)[0] = markers.ucharPtr(i, j)[0] + 1;
   //    if (unknown.ucharPtr(i, j)[0] === 255) {
   //      markers.intPtr(i, j)[0] = 0;
   //    }
   //  }
-  //}
+  // }
   cv.cvtColor(src, dst, cv.COLOR_RGBA2RGB, 0);
-  //cv.watershed(dst, markers);
+  // cv.watershed(dst, markers);
   const cloneSrc = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC4);
   const listContours = cv.Mat.zeros(src.rows, src.cols, cv.CV_8UC4);
   console.log(cv.COLOR_RGBA2RGB);

--- a/apps/segment/segmentpanel/segmentpanel.css
+++ b/apps/segment/segmentpanel/segmentpanel.css
@@ -170,6 +170,24 @@
   padding-right: 5px;
 }
 
+.annotation{
+  width:200px;
+  font-size: 12px;
+  text-align: center;
+  vertical-align: middle;
+}
+.annotation *{
+  padding: 1px 1px 1px 5px !important;
+  display:flex;
+  background-color:white;
+}
+.annotation textarea{
+  width:150px;
+  height:15px;
+  word-wrap: break-word;
+  word-break: break-all;
+}
+
 #csvDLB {
   display: none;
 }

--- a/apps/segment/segmentpanel/segmentpanel.js
+++ b/apps/segment/segmentpanel/segmentpanel.js
@@ -99,7 +99,7 @@ function SegmentPanel(viewer) {
   this.__oplabel = this.elt.querySelector('.segment-setting label#olabel');
   this.__opwrap = this.elt.querySelector('#owrap');
 
-  //annotation
+  // annotation
   this.__name = this.elt.querySelector('#_name');
   this.__notes = this.elt.querySelector('#_notes');
   this.__annotation = this.elt.querySelector('#_save');

--- a/apps/segment/segmentpanel/segmentpanel.js
+++ b/apps/segment/segmentpanel/segmentpanel.js
@@ -31,6 +31,13 @@ function SegmentPanel(viewer) {
         
         <canvas class='out'></canvas>
         <canvas id='mask' style='display: none;'></canvas>
+
+        <div class="annotation">
+          <label>Name:&nbsp&nbsp<textarea id='_name'></textarea></label>
+          <label>Notes:&nbsp&nbsp<textarea id='_notes'></textarea></label>
+          <button id='_save'>Save</button>
+        </div>
+
         <canvas id='dummy' style='display: none;'></canvas>
         <canvas class='src'></canvas>
         <canvas id='hemo' class='hiddenCanvas'></canvas>
@@ -91,6 +98,11 @@ function SegmentPanel(viewer) {
   this.__opacity = this.elt.querySelector('.segment-setting input[type=range]#opacity');
   this.__oplabel = this.elt.querySelector('.segment-setting label#olabel');
   this.__opwrap = this.elt.querySelector('#owrap');
+
+  //annotation
+  this.__name = this.elt.querySelector('#_name');
+  this.__notes = this.elt.querySelector('#_notes');
+  this.__annotation = this.elt.querySelector('#_save');
 
   this.viewer.addOverlay({
     element: this.elt,
@@ -186,10 +198,10 @@ SegmentPanel.prototype.hideProgress = function() {
   this.__indicator.style.display = 'none';
 };
 
-SegmentPanel.prototype.toggleMask = function() {
+SegmentPanel.prototype.toggleMask = function(e=0) {
   console.log('toggleMask');
 
-  if (this.__mask.style.display == 'none') {
+  if (this.__mask.style.display == 'none' && e!=2 || e==1) {
     this.__mask.style.display = '';
     this.__out.style.display = 'none';
   } else {

--- a/apps/table.html
+++ b/apps/table.html
@@ -29,9 +29,9 @@
 
 	<script src="https://code.jquery.com/jquery-3.4.1.min.js"
 		></script>
-		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.min.css" 
-		rel="stylesheet" 
-		integrity="sha384-wEmeIV1mKuiNpC+IOBjI7aAzPcEZeedi5yW5f2yOq55WWLwNGmvvx4Um1vskeMj0" 
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/css/bootstrap.min.css"
+		rel="stylesheet"
+		integrity="sha384-wEmeIV1mKuiNpC+IOBjI7aAzPcEZeedi5yW5f2yOq55WWLwNGmvvx4Um1vskeMj0"
 		crossorigin="anonymous">
 	<link rel="stylesheet" href="../common/stacktable.css">
 
@@ -110,7 +110,7 @@
                     </div>
                     <div class="row" id="filters-check" >
                     </div>
-                    <div class="search-box float-left form-group d-md-inline-flex">
+                    <div class="search-box float-left form-group d-md-inline-flex mb-4">
                         <div class="w-sm-50 pl-md-2 pt-2">
                         <select id='entries' class="select form-control">
                             <option value="10" selected>10 slides/page</option>
@@ -126,13 +126,13 @@
                         </div>
                     </div>
                 </div>
-                <div class="table-responsive " style="margin-left:4%;">
+                <div class="table-responsive ">
                     <table id='datatables' class="table table-striped"></table>
                 </div>
             </div>
             </div>
-          
-            <div class="d-md-inline-flex">
+
+            <div class="d-md-inline-flex" style="width:18%;">
                 <div class="pl-md-2 pt-2">
                     <button type="button" class="btn btn-success float-right w-md-100"
                         onclick="(()=>{location.reload();return false;})()"> <i class="fas fa-sync-alt"></i>

--- a/apps/table.js
+++ b/apps/table.js
@@ -590,7 +590,7 @@ function checkUserPermissions() {
             $('td:nth-child(2)', this).unbind('mouseenter mouseleave');
             $('td:nth-child(2)', this).hover(function() {
               var content = $(this).html();
-              $(this).html(content + `<i style='font-size: small; margin-left:1em; cursor: pointer' onclick="changeSlideName('` + content + `', '` + currentId + `')" class="fas fa-pen" data-toggle="modal" data-target="#slideNameChangeModal"></i>`);
+              $(this).html(content + `<i style='font-size: small; margin-left:1em; cursor: pointer' onclick="changeSlideName('` + content + `', '` + currentId + `')" class="fas fa-pen" data-bs-toggle="modal" data-bs-target="#slideNameChangeModal"></i>`);
             }, function() {
               $(this).find('i').last().remove();
             });

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -663,15 +663,16 @@ async function initUIcomponents() {
       clearInterval(checkOverlaysDataReady);
       // for segmentation
       $CAMIC.viewer.segment = new segmentationanno(
-        $CAMIC,
-        $D,
-        $UI,
-        $D.params.slideId,
-        (id)=>
-          {$UI.layersViewerMinor.removeItemById(id, 'computer');
-           $UI.layersViewer.removeItemById(id, 'computer');}
+          $CAMIC,
+          $D,
+          $UI,
+          $D.params.slideId,
+          (id)=> {
+            $UI.layersViewerMinor.removeItemById(id, 'computer');
+            $UI.layersViewer.removeItemById(id, 'computer');
+          },
       );
-      
+
 
       // create control
 

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -228,11 +228,7 @@ function initCore() {
             $UI.annotPopup.showFooter();
             break;
           case 'computer':
-            // handle data.provenance.analysis.computation = `segmentation`
-            attributes = data.properties.scalar_features[0].nv;
-            body = {type: 'map', data: attributes};
-            $UI.annotPopup.hideFooter();
-            break;
+            return;
           default:
             return;
             // statements_def
@@ -666,11 +662,16 @@ async function initUIcomponents() {
     ) {
       clearInterval(checkOverlaysDataReady);
       // for segmentation
-      $CAMIC.viewer.createSegment({
-        store: $CAMIC.store,
-        slide: $D.params.data.slide,
-        data: [],
-      });
+      $CAMIC.viewer.segment = new segmentationanno(
+        $CAMIC,
+        $D,
+        $UI,
+        $D.params.slideId,
+        (id)=>
+          {$UI.layersViewerMinor.removeItemById(id, 'computer');
+           $UI.layersViewer.removeItemById(id, 'computer');}
+      );
+      
 
       // create control
 
@@ -1093,8 +1094,8 @@ function addComputerLayerItems(data) {
   const minorViewerData = $D.computerlayers.map((d) => {
     return {item: d, isShow: false};
   });
-  $UI.layersViewer.addItems(mainViewerData, 'segmentation');
-  $UI.layersViewerMinor.addItems(minorViewerData, 'segmentation');
+  $UI.layersViewer.addItems(mainViewerData, 'computer');
+  $UI.layersViewerMinor.addItems(minorViewerData, 'computer');
 }
 
 function addHeatmapLayerItems(data) {

--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -105,6 +105,15 @@ function multSelectorAction(size) {
         slide: $D.params.data.name,
         data: [],
       });
+      $minorCAMIC.viewer.segment = new segmentationanno(
+        $minorCAMIC,
+        $D,
+        $UI,
+        $D.params.slideId,
+        (id)=>
+          {$UI.layersViewerMinor.removeItemById(id, 'computer');
+           $UI.layersViewer.removeItemById(id, 'computer');}
+      );
     });
   } catch (error) {
     Loading.close();
@@ -1232,14 +1241,8 @@ async function callback(data) {
       return;
     }
 
-    if (item.typeName == 'segmentation') {
-      if (d.isShow) {
-        // add
-        camic.viewer.segment.addSegmentId(item.id);
-      } else {
-        // remove
-        camic.viewer.segment.removeSegmentId(item.id);
-      }
+    if (item.typeName == 'computer') {
+      camic.viewer.segment.loadsegmentation(item.id, d.isShow);
       return;
     }
     if (item.typeName == 'heatmap') {

--- a/apps/viewer/uicallbacks.js
+++ b/apps/viewer/uicallbacks.js
@@ -106,13 +106,14 @@ function multSelectorAction(size) {
         data: [],
       });
       $minorCAMIC.viewer.segment = new segmentationanno(
-        $minorCAMIC,
-        $D,
-        $UI,
-        $D.params.slideId,
-        (id)=>
-          {$UI.layersViewerMinor.removeItemById(id, 'computer');
-           $UI.layersViewer.removeItemById(id, 'computer');}
+          $minorCAMIC,
+          $D,
+          $UI,
+          $D.params.slideId,
+          (id)=> {
+            $UI.layersViewerMinor.removeItemById(id, 'computer');
+            $UI.layersViewer.removeItemById(id, 'computer');
+          },
       );
     });
   } catch (error) {

--- a/apps/viewer/viewer.html
+++ b/apps/viewer/viewer.html
@@ -334,6 +334,10 @@
       type="text/javascript"
       src="../../core/extension/osd-segment-overlay.js"
     ></script>
+    <script
+      type="text/javascript"
+      src="../../core/extension/segment-annotation.js"
+    ></script>
 
     <!-- business js -->
     <!-- <script src="../../dist/packages.js"></script> -->

--- a/common/smartpen/autoalign.css
+++ b/common/smartpen/autoalign.css
@@ -1,56 +1,57 @@
- /*upper blocks*/
+/*upper blocks*/
 #align_menu *{
-  font-size:24px;
-  color:#0000be;/**/
-  padding: 0;
-  display: inline-block;
-  margin: 3px 3px 3px 3px;
+ font-size:24px;
+ color:#0000be;/**/
+ padding: 0;
+ display: inline-block;
+ margin: 3px 3px 3px 3px;
 }
 #align_menu button{
-  height:30px;
-  width:40px;
-  transition-duration: .2s;
-  border: 2px solid red;/**/
-  border-radius: 5px;
+ height:30px;
+ width:40px;
+ transition-duration: .2s;
+ border: 2px solid red;/**/
+ border-radius: 5px;
 }
 #align_mode{
-  color:red;
+ color:red;
 }
 #align_flag1:checked ~ #align_openbtn{
-  width:40px !important;
+ width:40px !important;
+ font-size:24px !important;
 }
 #align_flag1:checked ~ #align_mode{
-  transform: translateX(-40px) translateY(30px);
-  transition-duration: .2s;
+ transform: translateX(-43px) translateY(33px);
+ transition-duration: .2s;
 }
 #align_flag1:checked ~ #align_undoalign{
-  transform: translateX(0px) translateY(30px);
-  transition-duration: .2s;
+ transform: translateX(0px) translateY(33px);
+ transition-duration: .2s;
 }
 #align_flag1:checked ~ #align_setting{
-  transform: translateX(40px) translateY(30px);
-  transition-duration: .2s;
+ transform: translateX(43px) translateY(33px);
+ transition-duration: .2s;
 }
 /*Add more options here*/
 
 /*sliders*/
 #align_sliders{
-  display: none;
-  background-color:#ffffff4d;/**/
-  transform: translateX(40px) translateY(60px);
+ display: none;
+ background-color:#ffffff4d;/**/
+ transform: translateX(43px) translateY(66px);
 }
 #align_sliders *{
-  color:#07c691;/**/
-  font-size: 12px;
+ color:rgb(7, 198, 145);/**/
+ font-size: 12px;
 }
 #align_sliders input{
-  background:#90adfe;/**/
-  border: solid 1px #3f73ff;/**/
-  border-radius: 8px;
-  height: 7px;
-  outline: none;
-  -webkit-appearance: none;
+ background:	#0395fc;/**/
+ border: solid 1px #5555FF;/**/
+ border-radius: 8px;
+ height: 7px;
+ outline: none;
+ -webkit-appearance: none;
 }
 #align_flag2:checked ~ #align_sliders{
-    display: block;
+   display: block;
 }

--- a/common/smartpen/autoalign.js
+++ b/common/smartpen/autoalign.js
@@ -133,7 +133,7 @@ class smartpen {
     var temp = `
         <input type="checkbox" id="align_flag1" style="display:none;">
         <input type="checkbox" id="align_flag2" style="display:none;">
-        <button id="align_openbtn" style="z-index:602; width:100px;" class="material-icons">auto_graph</button>
+        <button id="align_openbtn" style="z-index:602; width:200px; font-size:17px;">Smart-Pen</button>
         <button id="align_mode" class="material-icons">power_settings_new</button>
         <button id="align_undoalign" class="material-icons">fast_rewind</button>
         <button id="align_setting" class="material-icons">tune</button>
@@ -172,10 +172,15 @@ class smartpen {
     var s = document.getElementById('align_s');
     var t = document.getElementById('align_t');
     var blink;
+    // logo change, blink and width, text
     openbtn.onclick = function() {
-      check1.checked=!check1.checked; if (!check1.checked)check2.checked=false;
+      check1.checked=!check1.checked;
+      if (!check1.checked) {
+        check2.checked=false; openbtn.innerHTML = 'Smart-Pen'; openbtn.className = '';
+      } else {
+        openbtn.innerHTML = 'auto_graph'; openbtn.className = 'material-icons';
+      }
     };
-    // logo change, blink and width
     mode.onclick = () => {
       this.mode = (this.mode+1)%3;
       if (this.mode == 0) {
@@ -241,7 +246,7 @@ class mathtoolSmartpen {
         var n = Math.min(~~(Math.sqrt(d)/c), m);
         for (var j=1; j<=n; j++) {
           var x = a[0] + j*(b[0]-a[0])/n; var y = a[1] + j*(b[1]-a[1])/n;
-          dist.push([x, y]);
+          dist.push([~~x, ~~y]);
         }
         prev = b;
       } else if (d>=low*low) {

--- a/common/util.js
+++ b/common/util.js
@@ -519,8 +519,8 @@ function covertToCumputerLayer(data) {
   return {
     id: id,
     name: id,
-    typeId: data.computation,
-    typeName: data.computation,
+    typeId: data.typeId,
+    typeName: data.source,
     creator: data.creator,
     data: null,
   };

--- a/components/layersviewer/layersviewer.js
+++ b/components/layersviewer/layersviewer.js
@@ -35,7 +35,7 @@ function LayersViewer(options) {
     // categoricalData
     isSortableView: false,
   };
-  this.defaultType = ['human', 'ruler', 'segmentation', 'heatmap'];
+  this.defaultType = ['human', 'ruler', 'computer', 'heatmap'];
 
   /**
    * @property {Object} _v_model
@@ -73,8 +73,8 @@ function LayersViewer(options) {
       item: {id: 'heatmap', name: 'heatmap'},
       items: [],
     },
-    'segmentation': {
-      item: {id: 'segmentation', name: 'segmentation'},
+    'computer': {
+      item: {id: 'computer', name: 'computer'},
       items: [],
     },
     'ruler': {
@@ -866,8 +866,8 @@ LayersViewer.prototype.__search = function(e) {
 
   const ruler = this.setting.categoricalData['ruler'].items;
   const heatmap = this.setting.categoricalData['heatmap'].items;
-  const segmentation = this.setting.categoricalData['segmentation'].items;
-  const list = [...human, ...ruler, ...heatmap, ...segmentation];
+  const computer = this.setting.categoricalData['computer'].items;
+  const list = [...human, ...ruler, ...heatmap, ...computer];
 
   list.forEach((data) => {
     data.elt.style.display = 'flex';

--- a/core/Store.js
+++ b/core/Store.js
@@ -272,7 +272,7 @@ class Store {
     const url = this.base + suffix;
     const query = {
       'provenance.analysis.execution_id': id,
-      'provenance.image.slide':slide,
+      'provenance.image.slide': slide,
     };
 
     return fetch(url + '?' + objToParamStr(query), {

--- a/core/Store.js
+++ b/core/Store.js
@@ -267,6 +267,19 @@ class Store {
       mode: 'cors',
     }).then(this.errorHandler).then((x) => this.filterBroken(x, 'mark'));
   }
+  getMarkbyExecId(id, slide) {
+    const suffix = 'Mark/find';
+    const url = this.base + suffix;
+    const query = {
+      'provenance.analysis.execution_id': id,
+      'provenance.image.slide':slide,
+    };
+
+    return fetch(url + '?' + objToParamStr(query), {
+      credentials: 'include',
+      mode: 'cors',
+    }).then(this.errorHandler).then((x) => this.filterBroken(x, 'mark'));
+  }
   fetchMark(slideId) {
     const suffix = 'Mark/find';
     const url = this.base + suffix;

--- a/core/extension/openseadragon-canvas-draw-overlay.js
+++ b/core/extension/openseadragon-canvas-draw-overlay.js
@@ -125,6 +125,7 @@
     this._hash_data = new Map();
     // aligndata
     this._align_data = [];
+    this._simplify = true;
 
     // -- create container div, and draw, display canvas -- //
     this._containerWidth = 0;
@@ -356,7 +357,7 @@
      */
     drawOn: function() {
       // stop turning on draw mode if already turn on
-      if (this.isOn === true) return;
+      if (this.isOn === true && this.moveOn === true) return;
       // clock viewer
       // this._viewer.controls.bottomright.style.display = 'none';
       this.updateView();
@@ -386,7 +387,7 @@
     drawOff: function() {
       // stop turning off draw mode if already turn off
       // if(this.contextMenu) this.contextMenu.
-      if (this.isOn === false) return;
+      if (this.isOn === false && this.moveOn == false) return;
       // unclock viewer
       // this._viewer.controls.bottomright.style.display = '';
       this._viewer.setMouseNavEnabled(true);
@@ -530,12 +531,12 @@
       }
       img_point.x = Math.round(img_point.x);
       img_point.y = Math.round(img_point.y);
-      img_point = this.__align_real(img_point);
       // set style for ctx
       DrawHelper.setStyle(this._draw_ctx_, this.style);
       this._draw_ctx_.fillStyle = hexToRgbA(this.style.color, 0.3);
 
       if (this.isDrawing) {
+        img_point = this.__align_real(img_point);
         switch (this.drawMode) {
           case 'free':
           // draw line
@@ -895,8 +896,8 @@
 
       // simplify and postprocess
       if(this.isMoving) spen.smoothness = spen.s;
-      if (!(this.drawMode === 'grid'))
-        if(spen.mode == 1)
+      if (!(this.drawMode === 'grid') && this._simplify)
+        if(spen.mode != 0)
           points = mtool.populate(points, 500000, ~~this.scaleWindowtoImage(2), 150);
         else
           points = simplify(points, 3.5);
@@ -1120,12 +1121,11 @@
     },
     __align_undo() {
       if (this._path_index > 0 && this._align_data.length) {
-        this._current_path_ = this._draws_data_[--this._path_index];
-      	this._draws_data_ = this._draws_data_.slice(0, this._path_index);
-      	this._current_path_.geometry.coordinates[0] = this._align_data;
         var tm = spen.mode; spen.mode = 3;
-        this.__endNewFeature();
-      	this.refresh_data();
+        var type = this._draws_data_[--this._path_index].geometry.type;
+        this._draws_data_ = this._draws_data_.slice(0, this._path_index);
+        this._redraw(this._align_data,type);
+        this.refresh_data();
         spen.mode = tm;
       } else this.undo();
     },
@@ -1182,6 +1182,14 @@
       let dx = this._viewer.viewport.windowToImageCoordinates(pt).x - this._viewer.viewport.windowToImageCoordinates(pt2).x;
       return dx;
     },
+    _redraw(data, type){
+      var t = this.drawMode
+      this.drawMode = type;
+      this.__newFeature(data[0]);
+      this._current_path_.geometry.coordinates[0] = data;
+      this.__endNewFeature();
+      this.drawMode = t;
+    }
   };
 
 

--- a/core/extension/segment-annotation.js
+++ b/core/extension/segment-annotation.js
@@ -48,7 +48,7 @@ class segmentationanno{
       resultString += str.substring(0, 36) + '\n';
       str = str.substring(36);}
     notes.notes = resultString;
-    const execId = "segment"+randomId();
+    const execId = notes.name+randomId();
 
     const annotJson = {
       creator: getUserId(),
@@ -128,8 +128,8 @@ class segmentationanno{
   deleteSegment = (p) => { //segmentation
     if (!confirm(`Are You Sure You Want To Delete This Segmentation {ID:${p.id}}?`)) return;
     this.data.splice(this.data.findIndex(e => e.id === p.id),1);
-    this.camic.viewer.omanager.removeOverlay(p.id);
     this.annotPopup.close();
+    this.camic.viewer.omanager.removeOverlay(p.id);
     if(this.deleteCallback)
       this.deleteCallback(p.id);
     this.camic.store

--- a/core/extension/segment-annotation.js
+++ b/core/extension/segment-annotation.js
@@ -1,0 +1,166 @@
+class segmentationanno{
+  constructor(camic, d, ui, slide, deleteCallback){
+    this.data = [];
+    this.slide = slide;
+    this.camic = camic;
+    this.ui = ui;
+    this.deleteCallback = deleteCallback;
+    this.annotPopup = new PopupPanel({
+      footer: [{
+          title: 'Delete',
+          class: 'material-icons',
+          text: 'delete_forever',
+          callback: this.deleteSegment,
+        },
+      ],
+    });
+    camic.viewer.addHandler('canvas-lay-click', e => {
+      if (!e.data) {
+        this.annotPopup.close();
+        return;
+      }
+      let data = Array.isArray(e.data) ? e.data[e.data.selected] : e.data;
+      let attributes = data.properties.annotations;
+      let body = convertHumanAnnotationToPopupBody(attributes);
+      this.annotPopup.data = {
+        id: data.provenance.analysis.execution_id,
+        oid: data._id.$oid,
+        annotation: attributes,
+        selected: data.selected,
+      };
+      this.annotPopup.dataType = null;
+      this.annotPopup.setTitle(`id:${data.provenance.analysis.execution_id}`);
+      this.annotPopup.setBody(body);
+      this.annotPopup.showFooter();
+      this.annotPopup.open(e.position);
+    });
+  }
+  saveSegment = (image,data,notes) => {
+    if(!data.features.length)
+      return;
+    if(!data.features[0].geometry.coordinates.length)
+      return;
+
+    // Add new lines to notes to prevent overflow
+    let str = notes.notes || '';
+    var resultString = '';
+    while (typeof str==='string' && str.length > 0) {
+      resultString += str.substring(0, 36) + '\n';
+      str = str.substring(36);}
+    notes.notes = resultString;
+    const execId = "segment"+randomId();
+
+    const annotJson = {
+      creator: getUserId(),
+      created_date: new Date(),
+      provenance: {
+        image: {
+          slide: this.slide,
+        },
+        analysis: {
+          typeId: 'computer',
+          source: 'computer',
+          execution_id: execId,
+          name: notes.name,
+        },
+      },
+      properties: {
+        annotations: notes
+      },
+      geometries:data,
+      image:image
+    };
+    this.camic.store
+        .addMark(annotJson)
+        .then((data) => {
+          console.log(data)
+          this.loadsegmentation(execId, true);
+        })
+        .catch((e) => {
+          this.ui.message.addError(e);
+          console.log('save failed', e);
+        })
+        .finally(() => {});
+  }
+  loadsegmentation = (id, isShow) => {
+    let u = this.data.findIndex(e => (e.id==id));
+    if(u==-1) this.loadSegById(id);
+    else{
+      if (!isShow && this.annotPopup.data && this.annotPopup.data.id===this.data[u].id) this.annotPopup.close();
+      this.data[u].layer.isShow = isShow;
+      this.camic.viewer.omanager.updateView();
+    }
+  }
+  loadSegById(id) {
+    this.camic.store
+        .getMarkbyExecId(id,this.slide)
+        .then((data) => {
+          // response error
+          if(data.error || !data[0]){
+            if(this.deleteCallback)
+              this.deleteCallback(id);
+            return;
+          }
+          let item = {data:data[0]};
+          let temp = {id:id,item:item};
+          item.id = id;
+          item.render = this.annoRender;
+          item.viewer = this.camic.viewer;
+          if(item.data.image)
+            item.data.image.data = new ImageData(new Uint8ClampedArray(item.data.image.data),item.data.image.width,item.data.image.height);
+          item.data.geometries.features.forEach((e)=>
+          {e.geometry.path = new Path();
+           e.properties.style = {
+                  color: '#FFFF00',
+                  lineCap: 'round',
+                  lineJoin: 'round',
+                  isFill: true};});
+          temp.layer = this.camic.viewer.omanager.addOverlay(item);
+          this.camic.viewer.omanager.updateView();
+          this.data.push(temp);
+        })
+        .catch((e) => {
+          console.error(e);
+        })
+        .finally(() => {
+        });
+  }
+  deleteSegment = (p) => { //segmentation
+    if (!confirm(`Are You Sure You Want To Delete This Segmentation {ID:${p.id}}?`)) return;
+    this.data.splice(this.data.findIndex(e => e.id === p.id),1);
+    this.camic.viewer.omanager.removeOverlay(p.id);
+    this.annotPopup.close();
+    if(this.deleteCallback)
+      this.deleteCallback(p.id);
+    this.camic.store
+        .deleteMarkByExecId(p.id, this.slide)
+        .then((datas) => {
+          console.log(datas);
+        })
+        .catch((e) => {
+          this.ui.message.addError(e);
+        })
+        .finally(() => {
+        });
+  }
+  annoRender(ctx, data) {
+    DrawHelper.draw(ctx, data.geometries.features);
+  }
+};
+function convertHumanAnnotationToPopupBody(notes) {
+  const rs = {type: 'map', data: []};
+  for (let field in notes) {
+    if (notes.hasOwnProperty(field)) {
+      const val = notes[field];
+      field = field
+          .split('_')
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(' ');
+      rs.data.push({key: field, value: val});
+    }
+  }
+  return rs;
+}
+`
+//$UI.message.addWarning('<i class="small material-icons">info</i> No Markup On Annotation. Try Holding And Dragging.');
+`;


### PR DESCRIPTION
Segmentation extension
### Contains
- Converted Segmentation results to annotations using contours and saved it for future use.
- Fixed slide renaming (slidechangemodal wasn't working earlier)
- Hopefully fixed the bug in moving-points (multi-mode) and also fixed canvas bugs in segmentation.
- Trivial UI changes

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/18577165/127754297-9d171bd9-8c0c-46d3-abff-6bcd0a5622d0.gif)

### Why?
Saving segmentation as annotations could be useful, as it can be used in future, and also could circle interesting areas as labels. Could also save whole image instead of contours as overlays but intentionally left it.  

### How?
I have added segmentation overlays which could be used both in viewer, side-by-side viewer and segmentation tabs. Currently, it can store name, notes and deletion can be done using popup-panel. 