### PR TITLE
fix ui: added margin between dropdown and search bar

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -110,7 +110,7 @@
                     </div>
                     <div class="row" id="filters-check" >
                     </div>
-                    <div class="search-box float-left form-group d-md-inline-flex mb-4">
+                    <div class="search-box float-left form-group d-md-inline-flex mb-4 mx-md-1">
                         <div class="w-sm-50 pl-md-2 pt-2">
                         <select id='entries' class="select form-control">
                             <option value="10" selected>10 slides/page</option>
@@ -120,7 +120,7 @@
                             <option value="100">100 slides/page</option>
                         </select>
                     </div>
-                        <div class="form-group has-search w-sm-50 pl-md-2 pt-2">
+                        <div class="form-group has-search w-sm-50 pl-md-2 pt-2 mx-md-1">
                             <span class="fa fa-search form-control-feedback"></span>
                             <input id="search-table" type="text" class="form-control" placeholder="Search">
                         </div>


### PR DESCRIPTION
Fixed UI on table.html page, added margin between search bar and dropdown menu

## Summary
before: 
![Screenshot_2021-09-20 CaMicroscope Data Table](https://user-images.githubusercontent.com/44988274/133959161-e2a5de25-c29e-41e5-9040-53be8f966576.png)
after:
![Screenshot_2021-09-20 CaMicroscope Data Table(1)](https://user-images.githubusercontent.com/44988274/133959179-53876da4-985b-4765-9ea6-2355e51b4993.png)


## Motivation
While doing code refactoring, I noticed that there was no margin between the mentioned two components. 

## Testing
This does not affect any functionality.

## Questions
I was thinking about doing more such changes to improve the UI. If that's okay, please assign me the task.