### PR TITLE
fix: incorrect active tab, fix: margin issue

### DIFF
--- a/apps/Info.html
+++ b/apps/Info.html
@@ -63,17 +63,15 @@
 							<li class="nav-item link" style="font-family: sans-serif;">
 							   <a class="nav-link" href="landing/landing.html"> <i class="fas fa-home"></i> Home</a>
 							</li>
-							<li class="nav-item active link" style="font-family: sans-serif;">
+							<li class="nav-item link" style="font-family: sans-serif;">
 								<a class="nav-link" href="table.html"> <i class="fas fa-list-ul"></i>  Slides</a>
 							</li>
-							<li class="nav-item link">
+							<li class="nav-item active link">
 								<a class="nav-link" href="Info.html"> <i class="fas fa-info-circle"></i> Info</a>
 							</li>
 							<li class="nav-item link">
 								<a class="nav-link" href="./dev-workbench/workbench.html"> <i class="fas fa-pencil-ruler"></i> Workbench</a>
 							</li>
-						</ul>
-						<ul class="navbar-nav ms-auto">
 							<li class="nav-item link" style="font-family: sans-serif;">
 								<a class="nav-link" href="./signup/signup.html"> <i class="fas fa-user-plus"></i> Signup</a>
 							</li>

--- a/apps/landing/landing.html
+++ b/apps/landing/landing.html
@@ -36,7 +36,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
     <div class="container-fluid">
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler m-1" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent" >
@@ -53,8 +53,6 @@
                     <li class="nav-item link">
                         <a class="nav-link" href="../dev-workbench/workbench.html"> <i class="fas fa-pencil-ruler"></i> Workbench</a>
                     </li>
-                </ul>
-                <ul class="navbar-nav ms-auto">
                     <li class="nav-item link" style="font-family: sans-serif;">
                         <a class="nav-link" href="../signup/signup.html"> <i class="fas fa-user-plus"></i> Signup</a>
                     </li>

--- a/apps/table.html
+++ b/apps/table.html
@@ -47,7 +47,7 @@
 	<div>
 	<nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
 		<div class="container-fluid">
-			<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+			<button class="navbar-toggler m-1" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
 				</button>
 				<div class="collapse navbar-collapse" id="navbarSupportedContent" >
@@ -64,8 +64,6 @@
 						<li class="nav-item link">
 							<a class="nav-link" href="./dev-workbench/workbench.html"> <i class="fas fa-pencil-ruler"></i> Workbench</a>
 						</li>
-					</ul>
-					<ul class="navbar-nav ms-auto">
 						<li class="nav-item link" style="font-family: sans-serif;">
 							<a class="nav-link" href="./signup/signup.html"> <i class="fas fa-user-plus"></i> Signup</a>
 						</li>


### PR DESCRIPTION
Removed extra code resulting in uneven margins, fixed: on info page active tab was "slides" instead of "info"

## Motivation
while exploring the site I noticed the margins were not equal on all pages,.

## Testing
These changes are just minor fixes in front end and does not affect the functionality of site. Tested on local host
