### PR TITLE
Handle uploading filenames with special characters

### DIFF
--- a/apps/batchloader/batchLoader.js
+++ b/apps/batchloader/batchLoader.js
@@ -198,7 +198,7 @@ function checkNames() {
       }
       numErrors++;
     } else if (!allowedExtensions.includes(fileNames[i].substring(fileNames[i].lastIndexOf('.')+1,
-        fileNames[i].length))) {
+        fileNames[i].length).toLowerCase())) {
       let errorIcon = `<i id='fileNameError' class="fas fa-exclamation-circle text-danger" title='File extension not allowed'></i> &nbsp;&nbsp;`;
       if ($('.fileNameEdit:eq('+i+')').prev().prev('#fileNameError').length == 0) {
         $('.fileNameEdit:eq('+i+')').parent().prepend(errorIcon);
@@ -346,8 +346,11 @@ function finishBatch() {
 }
 
 async function handleUpload(selectedFile, filename, i) {
-  const token = await startUpload(filename);
+  const uploadMetadata = await startUpload(filename);
+  const token = uploadMetadata.upload_token;
   tokens.push(token);
+  fileNames[i] = uploadMetadata.filename;
+  $('tr:eq('+(i+1)+') td:nth-child(2) span')[0].innerText = uploadMetadata.filename;
   let j = 0;
   $('.token').each(function() {
     $(this).html(tokens[j++]);
@@ -371,7 +374,7 @@ async function startUpload(filename) {
   }}).then((x)=>x.json());
   try {
     const a = await token;
-    return a['upload_token'];
+    return { upload_token: a['upload_token'], filename: a['filename'] };
   } catch (e) {
     console.log(e);
   }
@@ -395,6 +398,11 @@ function finishUpload(token, filename, i) {
   }});
   regReq.then((x)=>x.json()).then((a)=>{
     // changeStatus('UPLOAD | Finished', a, reset); reset = false;
+    if (a.filepath) {
+      const newName = a.filepath.slice(a.filepath.lastIndexOf('/')+1);
+      fileNames[i] = newName;
+      $('tr:eq('+(i+1)+') td:nth-child(2) span')[0].innerText = newName;
+    }
     if (typeof a === 'object' && a.error) {
       finishUploadSuccess = false;
     //   $('#check_btn').hide();

--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -59,12 +59,13 @@ async function readFileChunks(file, token) {
 async function handleUpload(selectedFiles) {
   selectedFile = selectedFiles[0];
   const filename = selectedFiles[0]['name'];
-  const token = await startUpload(filename);
+  const uploadMetadata = await startUpload(filename);
+  const token = uploadMetadata.upload_token;
   $('#tokenRow').show(300);
   const callback = continueUpload(token);
   readFileChunks(selectedFile, token);
   // parseFile(selectedFile, callback, 0, x=>(changeStatus("UPLOAD", "Finished Reading File")))
-  updateFormOnUpload(selectedFiles[0]['name'], token);
+  updateFormOnUpload(uploadMetadata.filename, token);
 
   document.getElementById('fileUploadInput').colSpan = selectedFiles.length;
   document.getElementById('controlButtons').colSpan = selectedFiles.length+1;
@@ -78,7 +79,7 @@ async function startUpload(filename) {
   try {
     const a = await token;
     changeStatus('UPLOAD', 'Begun upload - Token:' + a['upload_token']);
-    return a['upload_token'];
+    return { upload_token: a['upload_token'], filename: a['filename'] };;
   } catch (e) {
     changeStatus('UPLOAD | ERROR;', e);
   }
@@ -130,6 +131,9 @@ function finishUpload() {
   regReq.then((x)=>x.json()).then((a)=>{
     changeStatus('UPLOAD | Finished', a, reset); reset = false;
     console.log(a);
+    if (a.filepath) {
+      document.getElementById('filename'+0).value = a.filepath.slice(a.filepath.lastIndexOf('/')+1);
+    }
     if (typeof a === 'object' && a.error) {
       finishUploadSuccess = false;
       $('#check_btn').hide();
@@ -163,7 +167,7 @@ function finishUpload() {
 
 async function handleUrlUpload(url) {
   $('#uploadLoading').css('display', 'block');
-  const token = await startUpload(url);
+  const token = (await startUpload(url)).upload_token;
   await continueUrlUpload(token, url);
 }
 

--- a/apps/loader/chunked_upload.js
+++ b/apps/loader/chunked_upload.js
@@ -147,6 +147,7 @@ function finishUpload() {
         $('#check_btn').show();
         $('#post_btn').hide();
       }
+      validateForm(CheckBtn);
     }
   });
   regReq.then((e)=> {
@@ -157,8 +158,6 @@ function finishUpload() {
       changeStatus('UPLOAD | ERROR;', e);
       reset = true;
       console.log(e);
-    } else {
-      validateForm(CheckBtn);
     }
   },
   );


### PR DESCRIPTION
Currently, when a user tries to upload a filename such as “slide(1).svs”, Slideloader will save it as “slide1.svs” and tell the frontend about this. This happens when finalizing an upload. However the frontend discards this information and after finalizing, validates by calling the metadata API of “slide(1).svs”, which returns “Not found”, and the user never reaches the “success” stage.

## Summary

Firstly, the frontend should display the sanitized filename on upload finalization, and use this filename for validation.

Secondly, the frontend should also replace the filename with the sanitized one when starting upload.

Doing these both will give us good UX so that we won’t need to list: “the filename cannot contain (,), … etc”, but the user’s entered input will have these removed automatically and the user will understand instinctively that some characters aren’t allowed and will be removed.

## Motivation
Many filenames have special characters and this needs to be handled correctly

## Testing
I tested this patch with the following:
Filename with no special chars
Filename with ( or any other char
Filename with # (because this would be a special case if treated as a part of a URL)
The previous two cases, but now the user added the special chars after the original filename didn’t have them
Again, this time the user readded them after initial sanitizing
Filename with only special chars and extension
The previous but the user made it so after choosing a valid filenamed upload
Filename whose sanitization leads to conflict with a previous one
The previous but the original filename wouldn’t


## Questions
~~Say an `a.svs` file already exists. The user would like to upload `a.Svs`. caMicroscope will replace the textbox with `a.svs` and say: "a.svs already exists!" The user then thinks, "No, I really want a.**Svs** and this is a different file!" The frontend same-query filtering will not show and error message or generate requests and the user won't proceed until he picks a different filename.~~ In short, I thought it's best to not allow redundant queries to the backend in this case, since people, most likely those who would like to explor edge cases of caMicroscope, who would like to upload `a.svs a.Svs a.SvS a.sVs a.sVS ...` as different files are rare.

EDIT: I have now also added the patch for the batch loader