### PR TITLE
DICOM files

### DIFF
--- a/apps/batchloader/batchLoader.js
+++ b/apps/batchloader/batchLoader.js
@@ -11,7 +11,7 @@ let finishUrl = '../../loader/upload/finish/';
 let checkUrl = '../../loader/data/one/';
 let chunkSize = 5*1024*1024;
 let finishUploadSuccess = false;
-const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide'];
+const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide', 'dcm'];
 
 // call on document ready
 $(document).ready(function() {

--- a/apps/batchloader/batchloader.html
+++ b/apps/batchloader/batchloader.html
@@ -70,7 +70,7 @@
               type="file"
               class="custom-file-input"
               id="filesInput"
-              accept=".svs, .tif, .tiff, .vms, .vmu, .ndpi, .scn, .mrxs, .bif, .svslide"
+              accept=".svs, .tif, .tiff, .vms, .vmu, .ndpi, .scn, .mrxs, .bif, .svslide, .dcm"
               multiple
               required
             />

--- a/apps/table.js
+++ b/apps/table.js
@@ -13,7 +13,7 @@ function sanitize(string) {
 }
 var existingSlideNames = [];
 var permissions;
-const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide', 'jpg', 'png'];
+const allowedExtensions = ['svs', 'tif', 'tiff', 'vms', 'vmu', 'ndpi', 'scn', 'mrxs', 'bif', 'svslide', 'jpg', 'png', 'dcm'];
 function validateForm(callback) {
   let slide = document.getElementById('slidename0');
   // Check if input element is rendered or not


### PR DESCRIPTION
Subpullrequests: https://github.com/camicroscope/SlideLoader/pull/68 https://github.com/camicroscope/iipImage/pull/17

1) Allow `.dcm` extension
2) Use `caMicroscope/image-decoders`, our new repo, as the base Dockerfile that builds OpenSlide. If needed, `FROM camicroscope/image-decoders` can replaced with `apt-get install libopenslide0`.

Before merging, Tony and Nan don't have access to caMicroscope Docker so @birm could you please publish an image of currnet https://github.com/camicroscope/image-decoders to Docker Hub so that we can change the images to be downloaded from camicroscope rather than currently my repo for easy testing.

caMicroscope.yml for testing my three pullrequests:

```
version: '3'

services:
  mongo:
    image: mongo:4.2-bionic
    container_name: ca-mongo
    restart: always
    logging:
      options:
          max-file: "5"
          max-size: "10m"
    volumes:
      - ./db:/data/db
  back:
    build:
      context: "https://github.com/cgdogan/caracal.git#patch-2"
      args:
        viewer: "v3.10.2"
    depends_on:
      - "mongo"
    ports:
      - "4010:4010"
    container_name: ca-back
    restart: always
    logging:
      options:
          max-file: "5"
          max-size: "10m"
    volumes:
      - ./images/:/images/
      - ./config/login.html:/src/static/login.html
      - ./jwt_keys/:/src/keys/
      - ./config/routes.json:/src/routes.json
      - ./config/contentSecurityPolicy.json:/src/contentSecurityPolicy.json
    environment:
      JWK_URL: "https://www.googleapis.com/oauth2/v3/certs"
      IIP_PATH: "http://ca-iip:8080/fcgi-bin/iipsrv.fcgi"
      MONGO_URI: "mongodb://ca-mongo"
      DISABLE_SEC: "true"
      GENERATE_KEY_IF_MISSING: "true"
  iip:
    build: "https://github.com/CGDogan/iipimage.git#earlydcm"
    container_name: ca-iip
    logging:
      options:
          max-file: "5"
          max-size: "10m"
    restart: always
    volumes:
      - ./images/:/images/
  loader:
    build: "https://github.com/CGDogan/SlideLoader.git#earlydcm"
    container_name: ca-load
    restart: always
    logging:
      options:
          max-file: "5"
          max-size: "10m"
    volumes:
      - ./images/:/images/

```

What do you think?