### PR TITLE
Dicom button

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -133,7 +133,13 @@
             </div>
             </div>
 
-            <div class="d-md-inline-flex" style="width:18%;">
+            <div class="d-md-inline-flex" style="width:20%;">
+                <div class="pl-md-2 pt-2">
+                    <button type="button" data-bs-toggle="modal" data-bs-target="#dicom"
+                        class="btn btn2 btn-success float-right w-md-100" style="background-color: cadetblue; padding: 7px;" onclick="setDicomParams();"> <i
+                            class="fas fa-server"></i>
+                        <span class="">DICOM</span> </button>
+                </div>
                 <div class="pl-md-2 pt-2">
                     <button type="button" class="btn btn2 btn-success float-right w-md-100" style="padding: 7px;"
                         onclick="(()=>{location.reload();return false;})()"> <i class="fas fa-sync-alt"></i>
@@ -159,6 +165,38 @@
 	</div>
 
 
+        <div class="modal fade" id="dicom" tabindex="-1" role="dialog" aria-labelledby="title-of-dialog-dicom"
+            aria-hidden="true" data-backdrop="static" data-keyboard="false">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="title-of-dialog-dicom">DICOM Server</h5>
+                        <button type="button" class="close" onclick="initialize();" data-bs-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <table class="table table-borderless" cellpadding="5" style="margin-top: 1em" cellspacing="0">
+                            <tbody>
+                                <tr id="dicomServerRow">
+                                    <td align="right"><b>Server</b></td>
+                                    <td><input type="text" class="form-control" disabled=""
+                                            name="token" id="dicomServer"></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="text-center">
+                        <a id="dicomExplorerBtn" style="margin-top: 1em; margin-bottom: 4em" class="btn btn-info">DICOM
+                            Explorer</a>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" onclick="initialize();"
+                            data-bs-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
 
         <div class="modal fade" id="upload-dialog" tabindex="-1" role="dialog"
         aria-labelledby="title-of-dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">

--- a/apps/table.js
+++ b/apps/table.js
@@ -283,7 +283,7 @@ function initialize() {
                     rs.filterList = ['Public'];
                   }
                   rs.displayed = true;
-                  const filename = d.location.split('/')[d.location.split('/').length - 1];
+                  const filename = d.hasOwnProperty("filepath") ? d.filepath : d.location.split('/')[d.location.split('/').length - 1];
                   keys.forEach((key, i) => {
                     if (i == 0) rs.push(d['_id']['$oid']);
                     else if (key == 'review') {
@@ -996,4 +996,38 @@ function filterSlides() {
   totaltablepages = Math.ceil(newSlideRows.length / $('#entries').val());
   resetTable();
   pageIndicatorVisible(newSlideRows.length);
+}
+
+// sets #dicomServer.value and #dicomExplorerBtn.href
+async function setDicomParams() {
+  if (!$("#dicomExplorerBtn").attr("href")) {
+    let res = await fetch("/loader/dicomsrv/location");
+    let data = await res.json();
+    if (!res.ok) {
+      console.error(window.location.origin + "/loader/dicomsrv/location failed to retrieve port and ui_port. Got: " + JSON.stringify(data));
+      $("#dicomServer").attr("value", "UNCONFIGURED");
+      return;
+    }
+    let port = data.port;
+    let ui_port = data.ui_port;
+    let hostname = data.hostname;
+    let ui_hostname = data.ui_hostname;
+
+    if (!hostname) {
+      hostname = window.location.hostname
+    }
+    hostname = hostname.toLowerCase()
+
+    if (!ui_hostname) {
+      // Preserve http/https but not the port
+      ui_hostname = window.location.origin.split(":").slice(0, 2).join(":")
+    }
+    ui_hostname = ui_hostname.toLowerCase()
+    if (!ui_hostname.startsWith("http")) {
+      ui_hostname = "http://" + ui_hostname
+    }
+
+    $("#dicomExplorerBtn").attr("href", ui_hostname + ":" + ui_port);
+    $("#dicomServer").attr("value", hostname + ":" + port);
+  }
 }


### PR DESCRIPTION
Sorry, I forgot that I didn't open a pull request for this

Adds a dicom button to the table menu which fetches the port and ip from slideloader

In addition, fixes a case about handling filepaths to files in subdirs. These happen because we take "filename" from database or "location" from database and trim from the last slash. Instead we should use filepath from database whenever possible (Ryan, please remember this description so that if in the future you encounter any problems with files in subfolders, this is the cause and the fix)