### PR TITLE
Show tileserver errors as usual redirect

### DIFF
--- a/apps/heatmap/init.js
+++ b/apps/heatmap/init.js
@@ -60,10 +60,10 @@ function initCore() {
 
   $CAMIC.loadImg(async function(e) {
     Loading.open(document.body, `Loading Data ...`);
-    $CAMIC.viewer.addHandler('open-failed', function(e){
-      console.error(e.message, e)
+    $CAMIC.viewer.addHandler('open-failed', function(e) {
+      console.error(e.message, e);
       redirect($D.pages.table, e.message, 5);
-    })
+    });
     // image loaded
     if (e.hasError) {
       $UI.message.addError(e.message);

--- a/apps/heatmap/init.js
+++ b/apps/heatmap/init.js
@@ -60,6 +60,10 @@ function initCore() {
 
   $CAMIC.loadImg(async function(e) {
     Loading.open(document.body, `Loading Data ...`);
+    $CAMIC.viewer.addHandler('open-failed', function(e){
+      console.error(e.message, e)
+      redirect($D.pages.table, e.message, 5);
+    })
     // image loaded
     if (e.hasError) {
       $UI.message.addError(e.message);

--- a/apps/labeling/labeling.js
+++ b/apps/labeling/labeling.js
@@ -77,6 +77,10 @@ function initCore() {
         defaultText: `Slide: ${$D.params.data.name}`,
       });
     }
+    $CAMIC.viewer.addHandler('open-failed', function(e){
+      console.error(e.message, e)
+      redirect($D.pages.table, e.message, 5);
+    })
   });
 
   $CAMIC.viewer.addHandler('open', function() {

--- a/apps/labeling/labeling.js
+++ b/apps/labeling/labeling.js
@@ -77,10 +77,10 @@ function initCore() {
         defaultText: `Slide: ${$D.params.data.name}`,
       });
     }
-    $CAMIC.viewer.addHandler('open-failed', function(e){
-      console.error(e.message, e)
+    $CAMIC.viewer.addHandler('open-failed', function(e) {
+      console.error(e.message, e);
       redirect($D.pages.table, e.message, 5);
-    })
+    });
   });
 
   $CAMIC.viewer.addHandler('open', function() {

--- a/apps/mini/init.js
+++ b/apps/mini/init.js
@@ -161,6 +161,10 @@ function initCore() {
   }
 
   $CAMIC.loadImg(function(e) {
+    $CAMIC.viewer.addHandler('open-failed', function(e){
+      console.error(e.message, e)
+      redirect($D.pages.table, e.message, 5);
+    })
     // image loaded
     if (e.hasError) {
       // if this is a retry, assume normal behavior (one retry per slide)

--- a/apps/model/model.js
+++ b/apps/model/model.js
@@ -404,6 +404,10 @@ function initCore() {
     } else {
       $D.params.data = e;
     }
+    $CAMIC.viewer.addHandler('open-failed', function(e){
+      console.error(e.message, e)
+      redirect($D.pages.table, e.message, 5);
+    })
   });
 
   $CAMIC.store.getSlide($D.params.slideId).then((response) => {

--- a/apps/model/model.js
+++ b/apps/model/model.js
@@ -404,10 +404,10 @@ function initCore() {
     } else {
       $D.params.data = e;
     }
-    $CAMIC.viewer.addHandler('open-failed', function(e){
-      console.error(e.message, e)
+    $CAMIC.viewer.addHandler('open-failed', function(e) {
+      console.error(e.message, e);
       redirect($D.pages.table, e.message, 5);
-    })
+    });
   });
 
   $CAMIC.store.getSlide($D.params.slideId).then((response) => {

--- a/apps/segment/segment.js
+++ b/apps/segment/segment.js
@@ -371,10 +371,10 @@ function initCore() {
     } else {
       $D.params.data = e;
     }
-    $CAMIC.viewer.addHandler('open-failed', function(e){
-      console.error(e.message, e)
+    $CAMIC.viewer.addHandler('open-failed', function(e) {
+      console.error(e.message, e);
       redirect($D.pages.table, e.message, 5);
-    })
+    });
   });
 
   $CAMIC.viewer.addOnceHandler('open', function(e) {

--- a/apps/segment/segment.js
+++ b/apps/segment/segment.js
@@ -371,6 +371,10 @@ function initCore() {
     } else {
       $D.params.data = e;
     }
+    $CAMIC.viewer.addHandler('open-failed', function(e){
+      console.error(e.message, e)
+      redirect($D.pages.table, e.message, 5);
+    })
   });
 
   $CAMIC.viewer.addOnceHandler('open', function(e) {

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -195,10 +195,10 @@ function initCore() {
   }
 
   $CAMIC.loadImg(function(e) {
-    $CAMIC.viewer.addHandler('open-failed', function(e){
-      console.error(e.message, e)
+    $CAMIC.viewer.addHandler('open-failed', function(e) {
+      console.error(e.message, e);
       redirect($D.pages.table, e.message, 5);
-    })
+    });
     // image loaded
     if (e.hasError) {
       // if this is a retry, assume normal behavior (one retry per slide)

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -195,6 +195,10 @@ function initCore() {
   }
 
   $CAMIC.loadImg(function(e) {
+    $CAMIC.viewer.addHandler('open-failed', function(e){
+      console.error(e.message)
+      alert("failed!")
+    })
     // image loaded
     if (e.hasError) {
       // if this is a retry, assume normal behavior (one retry per slide)

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -196,8 +196,8 @@ function initCore() {
 
   $CAMIC.loadImg(function(e) {
     $CAMIC.viewer.addHandler('open-failed', function(e){
-      console.error(e.message)
-      alert("failed!")
+      console.error(e.message, e)
+      redirect($D.pages.table, e.message, 5);
     })
     // image loaded
     if (e.hasError) {


### PR DESCRIPTION
It used to stay stuck loading on a failure of the tile server forever, now it gives some info.

Before:
![Screenshot 2024-01-10 at 6 51 20 PM](https://github.com/camicroscope/caMicroscope/assets/4951803/68e54c69-ac64-4c08-b181-2cef8219a3ee)

After:
![Screenshot 2024-01-10 at 6 50 48 PM](https://github.com/camicroscope/caMicroscope/assets/4951803/c335ebff-1784-40a4-9893-04f8f4ec8cc6)
