### PR TITLE
Fixes #606 : This Pull Request resolves the bug that was preventing the ML kit help-guide from functioning properly.

### DIFF
--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -121,6 +121,7 @@
               href="#"
               data-toggle="modal"
               data-target="#helpModal"
+              onClick="displayUserGuide()"
             >
               <i class="fas fa-question-circle"></i>
               &nbsp;&nbsp;Help/User Guide</a

--- a/apps/dev-workbench/workbench.js
+++ b/apps/dev-workbench/workbench.js
@@ -494,14 +494,14 @@ function importWork() {
 }
 
 // getting markdown from readme.md and parsing/displaying it as user-guide
-$('.helpButton').click(function() {
+function displayUserGuide() {
   fetch('./readme.md').then((res) => res.blob()).then((blob) => {
     let f = new FileReader();
     f.onload = function(e) {
-      $('#helpModal .modal-body').html(marked(e.target.result));
+      $('#helpModal .modal-body').html(marked.marked(e.target.result));
       $('#helpModal .modal-body td, #helpModal .modal-body th')
           .css('border', '2px solid #dddddd').css('padding', '5px');
     };
     f.readAsText(blob);
   });
-});
+}


### PR DESCRIPTION
This Pull Request addresses the issue that was causing the ML kit help-guide to malfunction. The root cause was an improper usage of the ‘marked’ library, which is responsible for parsing Markdown into HTML.

Changed files :: `apps/dev-workbench/workbench.js` and `apps/dev-workbench/workbench.html`.

Before changes ::

https://github.com/camicroscope/caMicroscope/assets/124369508/f1a304a1-0860-4b3f-9f3e-5ec7d10f773f

After changes ::

https://github.com/camicroscope/caMicroscope/assets/124369508/6ea40b47-8787-4131-9172-ee00a213f915



