### PR TITLE
Fixed issue Login page #724

### DIFF
--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -109,7 +109,7 @@
           If you are an Admin, you can directly signup users.
         </p>
       </form>
-      <div class="text-center" onclick="loginPage()">Already have an account? </div>
+      <div class="text-center" onclick="loginPage()"><a href="/login.html">Already have an account?</a> </div>
     </div>
     <footer class="text-center text-white bg-dark p-3">
       <p class="p">Copyright © 2021 caMicroscope</p>

--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -109,7 +109,7 @@
           If you are an Admin, you can directly signup users.
         </p>
       </form>
-      <div class="text-center"><a href="/login.html">Already have an account?</a> </div>
+      <div class="text-center"><a href="../..//login.html">Already have an account?</a> </div>
     </div>
     <footer class="text-center text-white bg-dark p-3">
       <p class="p">Copyright © 2021 caMicroscope</p>

--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -109,7 +109,7 @@
           If you are an Admin, you can directly signup users.
         </p>
       </form>
-      <div class="text-center" onclick="loginPage()"><a href="/login.html">Already have an account?</a> </div>
+      <div class="text-center"><a href="/login.html">Already have an account?</a> </div>
     </div>
     <footer class="text-center text-white bg-dark p-3">
       <p class="p">Copyright © 2021 caMicroscope</p>

--- a/apps/signup/signup.js
+++ b/apps/signup/signup.js
@@ -114,6 +114,5 @@ $(window).on('load', function() {
 });
 
 function loginPage(){
-  const url = "/login.html";
-  window.location.href = url;
+  window.location.href = "/login.html";
 }

--- a/apps/signup/signup.js
+++ b/apps/signup/signup.js
@@ -113,6 +113,3 @@ $(window).on('load', function() {
   });
 });
 
-function loginPage(){
-  window.location.href = "/login.html";
-}


### PR DESCRIPTION
Fixed issue #724 Login page 

## Summary
This proposal aims to enhance the user experience on the caMicroscope platform by redirecting users to the login page when they click on the "Already have an account?" link on the Sign-Up HTML page.

## Motivation
My motivation for this Pull Request stems from my desire to contribute to the caMicroscope organization as an Outreachy applicant. I am eager to enhance my skills and knowledge while making a meaningful impact. By fixing issue #724, I aim to improve the user experience on the caMicroscope platform. This enhancement redirects users to the login page when they click on the "Already have an account?" link on the Sign-Up HTML page, streamlining the user journey and making the platform more user-friendly.

![signup](https://github.com/camicroscope/caMicroscope/assets/135106789/00dcdc9b-ad79-4e14-8332-241c831afcce)

