### PR TITLE
Enhanced navigation with a ‘Go Back’ Button feature on export page.

### DIFF
--- a/apps/port/export.html
+++ b/apps/port/export.html
@@ -3,9 +3,10 @@
 <head>
   <script src="../../core/Store.js"></script>
   <title>Export Results [caMicroscope]</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT" crossorigin="anonymous">
   <style>
-    #exportTitle{
+    .export--header{
       background-color: #17a2b8 !important;
       color: white;
     }
@@ -27,13 +28,23 @@
 </head>
 <body>
 
-  <h1 class="text-center py-5" id="exportTitle">Export Results</h1>
+  <!-- header -->
+  <div class="text-center export--header">
+    <div>
+      <h1 class="text-center py-2 m-0">Export Results</h1>
+      <p class="text-sm">Uncertain about the slide to export? Obtain its ID.</p>
+    </div>
+    <div>
+      <a href="javascript:history.back()" class="btn btn-primary mx-3 btn-sm my-2">Go Back</a>
+    </div>
+  </div>
+
   <div class="form text-center my-5">
   <label for="slide_id">Slide Ids (exact matches, comma delimited):</label>
-  <input type="text" class="mx-1" id="slide_id" name="slide_id">
-  <button id="populate_btn" onclick="populateList()" type="button" class="btn btn-primary mx-3">Get List of Results</button>
-
+  <input type="text" class="mx-1 mt-2" id="slide_id" name="slide_id">
+  <button id="populate_btn" onclick="populateList()" type="button" class="btn btn-primary mx-3 mt-2">Get List of Results</button>
   </div>
+
   <div class="result text-center">
     <h3>Select Results</h3>
     <div id="output"></div>


### PR DESCRIPTION
## Summary
The implemented feature adds a "Go Back" button link to our web application. When users click this button, they will be redirected to the previous page they were on.

## Screenshots
![home2](https://github.com/camicroscope/caMicroscope/assets/108942025/b2d83753-0769-4883-b846-33deb9741020)

![image](https://github.com/camicroscope/caMicroscope/assets/108942025/b611c4b8-48cd-48b7-9235-044a6cb1147d)
before

![responsive1](https://github.com/camicroscope/caMicroscope/assets/108942025/7417494c-553e-4113-8666-3d1d26200c64)
after

![md](https://github.com/camicroscope/caMicroscope/assets/108942025/b3abc026-0080-4611-b203-3968afbab2ba)

## video

https://github.com/camicroscope/caMicroscope/assets/108942025/91ec9bda-870b-4053-a081-4664e52eaff0



## Motivation
The motivation behind implementing this feature was that, at first glance, after I have visited the export page, I noticed that I needed to copy the id, and so I thought we could add a back feature where I will go back and grab the id. Users often expect a way to easily return to the previous page, especially in our case when someone hasn't copied the id or maybe wants to go back and copy more.

## Implementation
I have added a new button element with appropriate styling (using bootstrap) and labeled it "Go Back."
In the button's click event handler, I used JavaScript to navigate back in the browser history using `window.history.back()`.

## Testing
I have tested the feature using other browsers and also run the linting and all passes. I have also demonstrated the demo in the video above.

## Questions
No questions; I am open to improvements. 