### PR TITLE
 Dark mode functionality and toggle for  the slides (table) page

### DIFF
--- a/apps/table.css
+++ b/apps/table.css
@@ -35,11 +35,15 @@ footer {
   font-family: "Open Sans", Helvetica, sans-serif;
   /* line-height: 1.8; */
 }
-.bg-dark {
-  background-color: #343a40 !important;
-}
+
 .bg-info {
   background-color: #17a2b8 !important;
+}
+
+
+
+.bg-white{
+  border-color: white;
 }
 #collection-list li.item {
   cursor: pointer;
@@ -90,6 +94,67 @@ nav li:not(.active):hover a {
 nav li:not(.active):hover{
 	background: white;
 }
+
+/* This codes styles the dark mode the light/mode icon */
+
+
+#toggle-icon{
+  position: fixed;
+   right: 2%;	
+   top:2.4%;
+ }
+ 
+#toggle-icon.fa-moon {
+  color: #808080;
+  cursor: pointer;
+  background-color: #4a719b;
+  border-radius: 50%;
+  padding: 0.4rem;
+  
+}
+
+#toggle-icon.fa-sun {
+  color: rgb(190, 190, 44);
+  cursor: pointer;
+  background-color: #4a719b;
+  border-radius: 50%;
+  padding: 0.4rem;
+}
+
+.dark-mode {
+  background-color:  #212529;
+  color: white;
+}
+
+.darkmovenav{
+  background-color: black !important ;
+ }
+
+.p-color {
+  color: white;
+}
+
+.h2-color,
+.h3-color {
+  color: rgb(173, 191, 214);
+}
+
+a.button.content-buttoncolor {
+  color: white;
+  border:0.4px solid white;
+ 
+}
+
+.bg-whiteslide{
+background-color: black !important;
+border-color: black !important;
+color: white !important;
+}
+
+.modal-content-dark{
+  background-color:  #212529 !important;
+}
+
 
 .overall {
   display: flex;
@@ -235,3 +300,10 @@ nav li:not(.active):hover{
 .p {
   margin-bottom: 0;
 }
+
+.collectionsSection{
+  background-color: rgb(148, 140, 140) !important;
+}
+
+
+

--- a/apps/table.html
+++ b/apps/table.html
@@ -40,6 +40,72 @@
 <script src='../common/stacktable.js'></script>
 	<link rel="stylesheet" href="./table.css" />
 	<link rel="shortcut icon" type="image/x-icon" href="/apps/landing/favicon.png">
+    <script>
+
+        // Dark mode functionality
+        
+          function toggleTheme() {
+        // Get the icon element
+        const icon = document.getElementById('toggle-icon');
+        const contentsButton = document.querySelectorAll('.button');
+        const paragraphs = document.querySelectorAll('p');
+        const heading2 = document.querySelectorAll('h2');
+        const heading3 = document.querySelectorAll('h3');
+        const navdarkmode = document.querySelectorAll('.bg-dark');
+        const slideMode = document.querySelectorAll('.bg-white');
+        const collection = document.querySelector('.p-2');
+
+        
+
+        
+
+    
+        // Toggle dark mode class on body
+        document.body.classList.toggle("dark-mode");
+       
+    
+        // Toggle custom color class on  elements
+        paragraphs.forEach(p => p.classList.toggle("p-color"));
+        heading2.forEach(h2 => h2.classList.toggle("h2-color"));
+        heading3.forEach(h3 => h3.classList.toggle("h3-color"));
+        contentsButton.forEach(button => button.classList.toggle("content-buttoncolor"));
+        navdarkmode.forEach(item => item.classList.toggle("darkmovenav"));
+        slideMode.forEach(item => item.classList.toggle("bg-whiteslide"));
+        collection.classList.toggle("collectionsSection")
+      
+        
+        
+    
+         // Toggle dark class on the icon
+    if (icon.classList.contains("fa-sun")) {
+        icon.classList.remove("fa-sun");
+        icon.classList.add("fa-moon");
+    } else {
+        icon.classList.remove("fa-moon");
+        icon.classList.add("fa-sun");
+    }
+
+    }
+
+    function dicom () {
+
+        if (document.body.classList.contains("dark-mode")) {
+            document.querySelector(".modal-content").style.backgroundColor = "#212529";
+            document.querySelector(".modal-content").style.color = "white";
+            document.querySelector(".serverText").style.color = " white";
+        } else{
+            document.querySelector(".modal-content").style.backgroundColor = "white";
+            // document.querySelector(".modal-content").style.color = "black";
+            // document.querySelector(".servertext").style.color = " black ";
+
+        }
+     
+    }
+    
+    
+    
+    
+        </script>
 </head>
 
 <body>
@@ -76,6 +142,7 @@
 					</ul>
 				</div>
 		</div>
+        <i id="toggle-icon" class="fas fa-sun" onclick="toggleTheme()"></i>
 	</nav>
 
 	<div class="header text-center text-white bg-info p-4">
@@ -84,7 +151,7 @@
 		<div style="align-content: center;">
 			<div style="align-content: center;">
 				<div class="btn-group" role="group">
-				<button type="button" style="border-color: white;" class="btn btn-secondary bg-white text-dark" title="Slides Table"><i class="fas fa-list-alt"></i>  Slides</button>
+				<button type="button"  class="btn btn-secondary bg-white text-dark" title="Slides Table"><i class="fas fa-list-alt"></i>  Slides</button>
 				<a href="./Info.html">	<button style="border-color: white; border-radius: 0 5px 5px 0;" type="button" class="btn btn-secondary bg-info text-light" title="Information Dashboard"><i class="fas fa-info-circle"></i>  Info</button> </a></div>
 			</div>
 		</div>
@@ -136,7 +203,7 @@
             <div class="d-md-inline-flex" style="width:20%;">
                 <div class="pl-md-2 pt-2">
                     <button type="button" data-bs-toggle="modal" data-bs-target="#dicom"
-                        class="btn btn2 btn-success float-right w-md-100" style="background-color: cadetblue; padding: 7px;" onclick="setDicomParams();"> <i
+                        class="btn btn2 btn-success float-right w-md-100" style="background-color: cadetblue; padding: 7px;" onclick="setDicomParams();dicom();"> <i
                             class="fas fa-server"></i>
                         <span class="">DICOM</span> </button>
                 </div>
@@ -179,7 +246,7 @@
                         <table class="table table-borderless" cellpadding="5" style="margin-top: 1em" cellspacing="0">
                             <tbody>
                                 <tr id="dicomServerRow">
-                                    <td align="right"><b>Server</b></td>
+                                    <td align="right"class="serverText"><b >Server</b></td>
                                     <td><input type="text" class="form-control" disabled=""
                                             name="token" id="dicomServer"></td>
                                 </tr>


### PR DESCRIPTION
Summary
This pull request implements dark mode functionality and a toggle for the slides (table) page. Users can now switch between dark and light modes seamlessly, enhancing the visual experience of the slides page.

Motivation
The motivation behind this pull request is to improve user experience on the slides page by providing a dark mode option. This feature aims to cater to users who prefer a darker interface, reducing eye strain and making viewing slides more comfortable, especially in low-light conditions.

Testing
Extensive manual testing has been conducted to ensure the smooth functioning of the dark mode toggle on the slides page. Testing involved checking the compatibility of the feature across different browsers and devices to guarantee a consistent experience for all users.

Questions
If there are any uncertainties regarding the implementation or if feedback is sought for any aspect of the changes, please feel free to provide input or ask questions.
![darkmodetable](https://github.com/camicroscope/caMicroscope/assets/77133593/1468efc2-af83-4704-949c-7b45891d00a8)
