### PR TITLE
Enhance Session Tracking with Unique viewId in Tracker Class

### DIFF
--- a/common/util.js
+++ b/common/util.js
@@ -1013,6 +1013,11 @@ class Tracker {
     this.__period = period;
     this.__userId = userId;
     this.__slide = slide;
+    this.__viewId = this.generateViewId();
+  }
+
+  generateViewId() {
+    return crypto.randomUUID();
   }
   start() {
     if (!this.__time) {
@@ -1035,6 +1040,7 @@ class Tracker {
     );
 
     this.__camic.store.addLog({
+      viewId: this.__viewId,
       slide: this.__slide,
       user: this.__userId,
       x: Math.round(x),


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title -->

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
This update introduces a 'viewId' field to the Tracker class, ensuring each session is uniquely identifiable. The 'viewId' is generated using crypto.randomUUID() at the start of each session and is incorporated into all related log entries. This enhancement facilitates more accurate session tracking and analysis.
## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->
The introduction of the viewId field addresses the need for precise session identification and improves the efficiency of data querying and aggregation. For example, with viewId, leveraging MongoDB's aggregation capabilities to determine the start and end times of individual view sessions becomes straightforward.
<img width="995" alt="Screenshot 2024-03-19 at 1 21 22 AM" src="https://github.com/camicroscope/caMicroscope/assets/143434843/a6be0629-ebf8-4623-bd72-34f5ea6ee194">

Additionally, the introduction of the 'viewId' field lays a solid foundation for future enhancements to the logging system, such as tracking user annotation behaviors.

## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->
The addition of the 'viewId' field to the log collection has been tested. 
<img width="446" alt="Screenshot 2024-03-19 at 1 23 18 AM" src="https://github.com/camicroscope/caMicroscope/assets/143434843/c7557723-8560-4fc2-8340-5499677ec422">

## Questions

<!--- Are there any aspects you're unsure about? Are you looking for any feedback? -->

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
