### PR TITLE
Enhanced Slide Upload Instructions for caMicroscope

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -215,10 +215,10 @@
 
                                 <h3>Steps for uploading.</h3>
                                 <ul>
-                                    <li>Select the file as Input. The <b>Token</b> field should be filled automatically, and start uploading.</li>
-                                    <li> Provide the destination filename with extension.</li>
-                                    <li>Click on the <b><i class="fas fa-arrow-right"></i></b> button to get check a preview of the slide  </li>
-                                    <li>Finally <b>Finish Upload</b> to post the slide to caMicroscope</li>
+                                    <li>Select the file(.svs) you wish to upload. The <b>Token</b> field should be automatically populated .</li>
+                                    <li>Enter the desired filename, including its extension, for the destination file.</li> 
+                                    <li>Click on the <b><i class="fas fa-arrow-right"></i></b> button to preview the slide.</li> 
+                                    <li>Click on <b>Finish Upload</b> to complete the process and post the slide to caMicroscope.</li> 
                                 </ul>
                             </div>
                             <div>


### PR DESCRIPTION
This PR aims to improve the clarity of the exiting instructions for uploading slides to caMicroscope.

These enhancements should make the slide upload process more user-friendly and reduce potential errors.

## Motivation
New folks in the caMicroscope are finding it difficult to upload slides because of not so clear instructions.

Before changes : 
<img width="1440" alt="Screenshot 2024-03-19 at 12 57 57 PM" src="https://github.com/camicroscope/caMicroscope/assets/124369508/79b9919e-9591-40a7-aa17-96bb6ad2921c">

After changes :
<img width="1440" alt="Screenshot 2024-03-19 at 12 57 29 PM" src="https://github.com/camicroscope/caMicroscope/assets/124369508/34b1704b-8974-4778-8362-8a4184556e86">


