### PR TITLE
Work bench function duplication removed

### DIFF
--- a/apps/dev-workbench/workbench.css
+++ b/apps/dev-workbench/workbench.css
@@ -59,3 +59,33 @@
   }
 }
 
+.cards-div{
+
+  /* align-content: center; */
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
+
+
+
+}
+
+@media (max-width: 768px) {
+  .cards-div {
+    flex-direction: column;
+    row-gap: 2rem;
+
+
+  }
+}
+
+@media (max-width: 400px) {
+  .cards {
+    background-color: red;
+    width: fit-content;
+    font-size: smaller;
+  }
+  
+}
+

--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -71,7 +71,7 @@
         <i data-feather="arrow-left" class="text-white"></i>
       </div>
       
-<<<<<<< HEAD
+
       <!-- Navbar brand --> 
      
       <div class="navbar-brand-div flex-grow-1">
@@ -82,11 +82,11 @@
 
       
       <ul class="navbar-nav mr-auto px-2">
-=======
+
       <!-- Navbar brand -->
       <span style="cursor: default;" class="navbar-brand"> Workbench</span>
       <ul class="navbar-nav mr-auto">
->>>>>>> master
+
         <!-- Dropdown -->
         <li
           
@@ -230,22 +230,15 @@
     <!-- /.Vertical Steppers -->
     <div id="cards">
       <br /><br />
-      <div
-        style="
-          align-content: center;
-          display: flex;
-          flex-wrap: wrap;
-          padding: 1em;
-        "
-      >
+      <div class="cards-div"      >
         <!-- Cards -->
-        <div class="card" style="max-width: 20em; margin-left:2cm; auto;">
+        <div class="card" style="max-width: 20em; height: 16em; ">
           <!-- Card content -->
           <div class="card-body">
             <!-- Title -->
             <h4 class="card-title">Select your dataset</h4>
             <!-- Text -->
-            <p style="text-align: justify;" class="card-text">
+            <p style="padding: 0.2em;word-wrap: break-word;" class="card-text">
               Select the dataset (.zip) having three files; spritesheet
               (data.jpg), a binary labels (labels.bin) and the classes
               (labelnames.csv) from your local storage.
@@ -268,10 +261,10 @@
             </div>
           </div>
         </div>
-        <div style="height: 1em; margin-left:5cm; padding: 2em 0; font-size: large;">
+        <div style="height: 1em;  font-size: large;">
           <b> OR</b>
         </div>
-        <div class="card" style="max-width: 20em; margin-left:2cm; auto;">
+        <div class="card" style="max-width: 20em;height: 16em ">
           <!-- Card content -->
           <div class="card-body">
             <!-- Title -->

--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -340,13 +340,7 @@
                       accept=".zip"
                       required
                     />
-                    <label
-                      class="custom-file-label labelsInputLabel"
-                      for="labelsInput"
-                      style="overflow: hidden;"
-                    >
-                      Choose
-                    </label>
+                    
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Summary
This pull request aims to delete the duplicated "choose" button in the caM slide button located in the "Select caMircoscope labeling files" section of the workbench page.

Motivation
The motivation behind this change is to remove redundancy and improve the clarity and consistency of the user interface. By eliminating the duplicated button, we can enhance the usability of the page and provide a more streamlined experience for users.

Testing
Testing has been performed to ensure that the removal of the duplicated button does not impact the functionality of the caM slide button. Manual testing has been conducted to verify that users can still select caMircoscope labelling files without any issues.

Questions
I do not have any specific questions regarding this change. However, feedback on the UI improvement and suggestions for further enhancements are welcome.

BEFORE
![Screenshot 2024-03-19 202220](https://github.com/camicroscope/caMicroscope/assets/77133593/0ceb9440-ee69-4802-b69e-e49f876a3206)

NOW
![Screenshot 2024-03-19 202255](https://github.com/camicroscope/caMicroscope/assets/77133593/3d2c2210-2e04-4d66-9852-95fc75a34a3e)

