### PR TITLE
Select your dataset duplicated  function removed

### DIFF
--- a/apps/dev-workbench/workbench.css
+++ b/apps/dev-workbench/workbench.css
@@ -59,3 +59,33 @@
   }
 }
 
+.cards-div{
+
+  /* align-content: center; */
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
+
+
+
+}
+
+@media (max-width: 768px) {
+  .cards-div {
+    flex-direction: column;
+    row-gap: 2rem;
+
+
+  }
+}
+
+@media (max-width: 400px) {
+  .cards {
+    background-color: red;
+    width: fit-content;
+    font-size: smaller;
+  }
+  
+}
+

--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -71,7 +71,7 @@
         <i data-feather="arrow-left" class="text-white"></i>
       </div>
       
-<<<<<<< HEAD
+
       <!-- Navbar brand --> 
      
       <div class="navbar-brand-div flex-grow-1">
@@ -82,11 +82,11 @@
 
       
       <ul class="navbar-nav mr-auto px-2">
-=======
+
       <!-- Navbar brand -->
       <span style="cursor: default;" class="navbar-brand"> Workbench</span>
       <ul class="navbar-nav mr-auto">
->>>>>>> master
+
         <!-- Dropdown -->
         <li
           
@@ -230,22 +230,15 @@
     <!-- /.Vertical Steppers -->
     <div id="cards">
       <br /><br />
-      <div
-        style="
-          align-content: center;
-          display: flex;
-          flex-wrap: wrap;
-          padding: 1em;
-        "
-      >
+      <div class="cards-div"      >
         <!-- Cards -->
-        <div class="card" style="max-width: 20em; margin-left:2cm; auto;">
+        <div class="card" style="max-width: 20em; height: 16em; ">
           <!-- Card content -->
           <div class="card-body">
             <!-- Title -->
             <h4 class="card-title">Select your dataset</h4>
             <!-- Text -->
-            <p style="text-align: justify;" class="card-text">
+            <p style="padding: 0.2em;word-wrap: break-word;" class="card-text">
               Select the dataset (.zip) having three files; spritesheet
               (data.jpg), a binary labels (labels.bin) and the classes
               (labelnames.csv) from your local storage.
@@ -268,10 +261,10 @@
             </div>
           </div>
         </div>
-        <div style="height: 1em; margin-left:5cm; padding: 2em 0; font-size: large;">
+        <div style="height: 1em;  font-size: large;">
           <b> OR</b>
         </div>
-        <div class="card" style="max-width: 20em; margin-left:2cm; auto;">
+        <div class="card" style="max-width: 20em;height: 16em ">
           <!-- Card content -->
           <div class="card-body">
             <!-- Title -->

--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -251,12 +251,7 @@
                   accept=".zip"
                   style="max-width: 98%;"
                 />
-                <label
-                  style="overflow: hidden;"
-                  class="custom-file-label spriteInputLabel"
-                  for="spriteInput"
-                  >Choose file
-                </label>
+                
               </div>
             </div>
           </div>


### PR DESCRIPTION
This pull request removes the "Choose file" label from the "Select your dataset" section of the workbench page. The section already contains an input element with a type property of "file," making the additional "Choose file" text redundant.

Motivation
The motivation behind this change is to improve the visual clarity and consistency of the user interface. Removing the duplicated "Choose file" label enhances the aesthetics of the section and eliminates unnecessary repetition, resulting in a cleaner and more streamlined design.

Testing
Testing has been conducted to ensure that the removal of the "Choose file" label does not impact the functionality of the input element. Manual testing has been performed to verify that users can still select their dataset files without any issues after the label has been removed.

BEFORE
![Screenshot 2024-03-19 203702](https://github.com/camicroscope/caMicroscope/assets/77133593/f3794465-eec8-47c4-88fd-73bd2d79bc88)

NOW
![Screenshot 2024-03-19 203730](https://github.com/camicroscope/caMicroscope/assets/77133593/d73df49a-835e-4930-8cd2-9ee1f2b92cb0)

