### PR TITLE
Help section duplicated close button resolved

### DIFF
--- a/apps/dev-workbench/workbench.css
+++ b/apps/dev-workbench/workbench.css
@@ -59,3 +59,33 @@
   }
 }
 
+.cards-div{
+
+  /* align-content: center; */
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  flex-wrap: wrap;
+
+
+
+}
+
+@media (max-width: 768px) {
+  .cards-div {
+    flex-direction: column;
+    row-gap: 2rem;
+
+
+  }
+}
+
+@media (max-width: 400px) {
+  .cards {
+    background-color: red;
+    width: fit-content;
+    font-size: smaller;
+  }
+  
+}
+

--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -71,7 +71,7 @@
         <i data-feather="arrow-left" class="text-white"></i>
       </div>
       
-<<<<<<< HEAD
+
       <!-- Navbar brand --> 
      
       <div class="navbar-brand-div flex-grow-1">
@@ -82,11 +82,11 @@
 
       
       <ul class="navbar-nav mr-auto px-2">
-=======
+
       <!-- Navbar brand -->
       <span style="cursor: default;" class="navbar-brand"> Workbench</span>
       <ul class="navbar-nav mr-auto">
->>>>>>> master
+
         <!-- Dropdown -->
         <li
           
@@ -230,22 +230,15 @@
     <!-- /.Vertical Steppers -->
     <div id="cards">
       <br /><br />
-      <div
-        style="
-          align-content: center;
-          display: flex;
-          flex-wrap: wrap;
-          padding: 1em;
-        "
-      >
+      <div class="cards-div"      >
         <!-- Cards -->
-        <div class="card" style="max-width: 20em; margin-left:2cm; auto;">
+        <div class="card" style="max-width: 20em; height: 16em; ">
           <!-- Card content -->
           <div class="card-body">
             <!-- Title -->
             <h4 class="card-title">Select your dataset</h4>
             <!-- Text -->
-            <p style="text-align: justify;" class="card-text">
+            <p style="padding: 0.2em;word-wrap: break-word;" class="card-text">
               Select the dataset (.zip) having three files; spritesheet
               (data.jpg), a binary labels (labels.bin) and the classes
               (labelnames.csv) from your local storage.
@@ -268,10 +261,10 @@
             </div>
           </div>
         </div>
-        <div style="height: 1em; margin-left:5cm; padding: 2em 0; font-size: large;">
+        <div style="height: 1em;  font-size: large;">
           <b> OR</b>
         </div>
-        <div class="card" style="max-width: 20em; margin-left:2cm; auto;">
+        <div class="card" style="max-width: 20em;height: 16em ">
           <!-- Card content -->
           <div class="card-body">
             <!-- Title -->

--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -456,14 +456,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="helpModalTitle">Help - User Guide</h5>
-            <button
-              type="button"
-              class="close"
-              data-dismiss="modal"
-              aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
+            
           </div>
           <div class="modal-body" style="align-content: center;"></div>
           <div class="modal-footer">


### PR DESCRIPTION
Summary
This pull request removes the duplicated "close" button from the "Help user guide" section. The section previously contained both a "fa times" button and a "close" button, which served the same purpose. The "fa times" button has been removed to avoid redundancy and streamline the UI.

Motivation
The motivation behind this change is to enhance the clarity and simplicity of the user interface. Removing the duplicated "close" button ensures consistency and eliminates unnecessary repetition, resulting in a more user-friendly experience.

Testing
Testing has been conducted to ensure that the removal of the "fa times" button does not affect the functionality of the "close" button. Manual testing has been performed to verify that users can still close the "Help user guide" section without any issues after the button has been removed.

Questions
I do not have any specific questions regarding this change. However, feedback on the UI improvement and suggestions for further enhancements are welcome.

BEFORE
![Screenshot 2024-03-19 205521](https://github.com/camicroscope/caMicroscope/assets/77133593/db1ff0a1-5c30-415e-a142-b173c8868616)

NOW
![Screenshot 2024-03-19 210213](https://github.com/camicroscope/caMicroscope/assets/77133593/19befa59-a06a-4663-9ec6-dc727374a8fd)
