### PR TITLE
Fixed disabled in mobile view #830

### DIFF
--- a/apps/Info.html
+++ b/apps/Info.html
@@ -6,7 +6,7 @@
 	<meta charset='utf-8'>
 	<meta http-equiv='X-UA-Compatible' content='IE=edge'>
 	<meta name='viewport'
-		content='width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+		content='width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=2.0'>
 	<!-- common -->
 	<!-- <link rel='stylesheet' type='text/css' media='all' href='../css/style.css'/> -->
 	<!-- Check If we're logged in ok, otherwise, log in for us -->


### PR DESCRIPTION
Fixed disabled in mobile view #830



## Summary
Remove the user-scalable="no" parameter from the content attribute to allow zooming.
Add  maximum-scale=2.0 for ensuring that the maximum-scale parameter is not less than 2 to allow sufficient zooming.

By removing the user-scalable="no" parameter and ensuring the maximum-scale parameter is set appropriately, users will be able to zoom in and out on the Info Page in mobile view, improving accessibility for people with low vision.

## Motivation
I'm passionate about contributing to the caMicroscope organization to further my skills and knowledge. One of the issues I've successfully fixed is #830, which involved addressing the disabled zooming on the mobile view of the Info Page. I would appreciate a review of my work to ensure it meets the project's standards. This experience has deepened my understanding of user-centered design and my ability to create intuitive user interfaces.




