### PR TITLE
Fixed issue #837  HTML element does not have lang attribute 

### DIFF
--- a/apps/Info.html
+++ b/apps/Info.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
 	<meta name="keywords" content="camicroscope, quip" />

--- a/apps/heatmap/heatmap.html
+++ b/apps/heatmap/heatmap.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
 	<meta name="keywords" content="camicroscope, quip" />

--- a/apps/labeling/labeling.html
+++ b/apps/labeling/labeling.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
 	<meta name="keywords" content="camicroscope, quip" />

--- a/apps/model/model.html
+++ b/apps/model/model.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
   <meta name="keywords" content="camicroscope, quip"/>

--- a/apps/multi/multi.html
+++ b/apps/multi/multi.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 <head>
   <script type="text/javascript" src="../../core/openseadragon/openseadragon.js"></script>
   <script src="../../core/Store.js"></script>

--- a/apps/port/export.html
+++ b/apps/port/export.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 <head>
   <script src="../../core/Store.js"></script>
   <title>Export Results [caMicroscope]</title>

--- a/apps/port/import.html
+++ b/apps/port/import.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
   <script src="../../core/Store.js"></script>

--- a/apps/redir.html
+++ b/apps/redir.html
@@ -1,4 +1,4 @@
-<html>
+<html  lang="en">
 <script src='../common/util.js'></script>
 <script src='../core/Store.js'></script>
 <script src='../common/PathdbMods.js'></script>

--- a/apps/segment/segment.html
+++ b/apps/segment/segment.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
   <meta name="keywords" content="camicroscope, quip"/>

--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   <head>
     <meta name="keywords" content="camicroscope, quip" />

--- a/apps/table.html
+++ b/apps/table.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
 
 <head>
 	<meta name="keywords" content="camicroscope, quip" />

--- a/apps/viewer/viewer.html
+++ b/apps/viewer/viewer.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html  lang="en">
   <head>
     <meta name="keywords" content="camicroscope, quip" />
     <meta charset="utf-8" />

--- a/index.html
+++ b/index.html
@@ -1,3 +1,3 @@
-<html>
+<html  lang="en">
     <meta http-equiv="refresh" content="0; URL='apps/landing/landing.html'" />
 </html>


### PR DESCRIPTION
Fixed issue #837 

## Summary

HTML element does not have Lang attribute #837 
To fix this issue, I added the `lang` attribute to the `html` element and specify the appropriate language code that reflects the primary language of the content on the page. For example, for English content, I would use `lang="en"` in the `html` tag.

## Motivation

I'm passionate about contributing to the caMicroscope organization to further my skills and knowledge. One of the issues I've successfully fixed is [Accessibility] HTML element does not have lang attribute #837. I would appreciate a review of my work to ensure it meets the project's standards. This experience has deepened my understanding of user-centered design and my ability to create intuitive user interfaces.
