### PR TITLE
Added darkmode toggle icons and functionality to the Slides(table) page

### DIFF
--- a/apps/table.css
+++ b/apps/table.css
@@ -35,9 +35,7 @@ footer {
   font-family: "Open Sans", Helvetica, sans-serif;
   /* line-height: 1.8; */
 }
-.bg-dark {
-  background-color: #343a40 !important;
-}
+
 .bg-info {
   background-color: #17a2b8 !important;
 }
@@ -66,6 +64,10 @@ footer {
 #collection-list .item i {
   padding: 0.25rem;
 }
+.collectionsSection{
+  background-color: rgb(148, 140, 140) !important;
+}
+
 
 nav li {
   transition: background 0.5s;
@@ -235,3 +237,68 @@ nav li:not(.active):hover{
 .p {
   margin-bottom: 0;
 }
+
+
+/* This codes styles the dark mode the light/mode icon */
+
+
+#toggle-icon{
+  position: fixed;
+   right: 2%;	
+   top:2.4%;
+ }
+
+#toggle-icon.fa-moon {
+  color: #808080;
+  cursor: pointer;
+  background-color: #4a719b;
+  border-radius: 50%;
+  padding: 0.4rem;
+
+}
+
+#toggle-icon.fa-sun {
+  color: rgb(190, 190, 44);
+  cursor: pointer;
+  background-color: #4a719b;
+  border-radius: 50%;
+  padding: 0.4rem;
+}
+
+.dark-mode {
+  background-color:  #212529;
+  color: white;
+}
+
+.darkmovenav{
+  background-color: black !important ;
+ }
+
+.p-color {
+  color: white;
+}
+
+.h2-color,
+.h3-color {
+  color: rgb(173, 191, 214);
+}
+
+a.button.content-buttoncolor {
+  color: white;
+  border:0.4px solid white;
+
+}
+
+.bg-whiteslide{
+background-color: black !important;
+border-color: black !important;
+color: white !important;
+}
+
+.modal-content-dark{
+  background-color:  #212529 !important;
+}
+
+
+
+

--- a/apps/table.html
+++ b/apps/table.html
@@ -40,12 +40,82 @@
 <script src='../common/stacktable.js'></script>
 	<link rel="stylesheet" href="./table.css" />
 	<link rel="shortcut icon" type="image/x-icon" href="/apps/landing/favicon.png">
+      
+    <script src='../common/stacktable.js'></script>
+	<link rel="stylesheet" href="./table.css" />
+	<link rel="shortcut icon" type="image/x-icon" href="/apps/landing/favicon.png">
+    <script>
+
+        // Dark mode functionality
+
+          function toggleTheme() {
+        // Get the icon element
+        const icon = document.getElementById('toggle-icon');
+        const contentsButton = document.querySelectorAll('.button');
+        const paragraphs = document.querySelectorAll('p');
+        const heading2 = document.querySelectorAll('h2');
+        const heading3 = document.querySelectorAll('h3');
+        const navdarkmode = document.querySelectorAll('.bg-dark');
+        const slideMode = document.querySelectorAll('.bg-white');
+        const collection = document.querySelector('.p-2');
+
+
+
+
+
+
+        // Toggle dark mode class on body
+        document.body.classList.toggle("dark-mode");
+
+
+        // Toggle custom color class on  elements
+        paragraphs.forEach(p => p.classList.toggle("p-color"));
+        heading2.forEach(h2 => h2.classList.toggle("h2-color"));
+        heading3.forEach(h3 => h3.classList.toggle("h3-color"));
+        contentsButton.forEach(button => button.classList.toggle("content-buttoncolor"));
+        navdarkmode.forEach(item => item.classList.toggle("darkmovenav"));
+        slideMode.forEach(item => item.classList.toggle("bg-whiteslide"));
+        collection.classList.toggle("collectionsSection")
+
+
+
+
+         // Toggle dark class on the icon
+    if (icon.classList.contains("fa-sun")) {
+        icon.classList.remove("fa-sun");
+        icon.classList.add("fa-moon");
+    } else {
+        icon.classList.remove("fa-moon");
+        icon.classList.add("fa-sun");
+    }
+
+    }
+
+    function dicom () {
+
+        if (document.body.classList.contains("dark-mode")) {
+            document.querySelector(".modal-content").style.backgroundColor = "#212529";
+            document.querySelector(".modal-content").style.color = "white";
+            document.querySelector(".serverText").style.color = " white";
+        } else{
+            document.querySelector(".modal-content").style.backgroundColor = "white";
+            // document.querySelector(".modal-content").style.color = "black";
+            // document.querySelector(".servertext").style.color = " black ";
+
+        }
+
+    }
+
+
+
+
+        </script>
 </head>
 
 <body>
 	<div class="page-container">
 	<div>
-	<nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
+        <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
 		<div class="container-fluid">
 			<button class="navbar-toggler m-1" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 				<span class="navbar-toggler-icon"></span>
@@ -76,6 +146,7 @@
 					</ul>
 				</div>
 		</div>
+        <i id="toggle-icon" class="fas fa-sun" onclick="toggleTheme()"></i>
 	</nav>
 
 	<div class="header text-center text-white bg-info p-4">
@@ -133,11 +204,11 @@
             </div>
             </div>
 
-            <div class="d-md-inline-flex" style="width:20%;">
+            <div class="d-md-inline-flex " style="width:20%;">
                 <div class="pl-md-2 pt-2">
                     <button type="button" data-bs-toggle="modal" data-bs-target="#dicom"
-                        class="btn btn2 btn-success float-right w-md-100" style="background-color: cadetblue; padding: 7px;" onclick="setDicomParams();"> <i
-                            class="fas fa-server"></i>
+                    class="btn btn2 btn-success float-right w-md-100" style="background-color: cadetblue; padding: 7px;" onclick="setDicomParams();dicom();"> <i
+                    class="fas fa-server"></i>
                         <span class="">DICOM</span> </button>
                 </div>
                 <div class="pl-md-2 pt-2">
@@ -168,8 +239,8 @@
         <div class="modal fade" id="dicom" tabindex="-1" role="dialog" aria-labelledby="title-of-dialog-dicom"
             aria-hidden="true" data-backdrop="static" data-keyboard="false">
             <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg" role="document">
-                <div class="modal-content">
-                    <div class="modal-header">
+                <div class="modal-content bg-dark">
+                    <div class="modal-header ">
                         <h5 class="modal-title" id="title-of-dialog-dicom">DICOM Server</h5>
                         <button type="button" class="close" onclick="initialize();" data-bs-dismiss="modal" aria-label="Close">
                             <span aria-hidden="true">&times;</span>
@@ -179,7 +250,7 @@
                         <table class="table table-borderless" cellpadding="5" style="margin-top: 1em" cellspacing="0">
                             <tbody>
                                 <tr id="dicomServerRow">
-                                    <td align="right"><b>Server</b></td>
+                                    <td align="right"class="serverText"><b >Server</b></td>
                                     <td><input type="text" class="form-control" disabled=""
                                             name="token" id="dicomServer"></td>
                                 </tr>
@@ -333,7 +404,7 @@
 </div>
 
 
-<footer class="text-center text-white bg-dark p-3">
+<footer class="text-center text-white  bg-dark p-3">
 	<p class="p">Copyright © 2021 caMicroscope</p>
 </footer>
 


### PR DESCRIPTION

Summary
This pull request implements dark mode functionality and a toggle for the slides (table) page. Users can now switch between dark and light modes seamlessly, enhancing the visual experience of the slides page.

Motivation
The motivation behind this pull request is to improve user experience on the slides page by providing a dark mode option. This feature aims to cater to users who prefer a darker interface, reducing eye strain and making viewing slides more comfortable, especially in low-light conditions.

Testing
Extensive manual testing has been conducted to ensure the smooth functioning of the dark mode toggle on the slides page. Testing involved checking the compatibility of the feature across different browsers and devices to guarantee a consistent experience for all users.

Questions
If there are any uncertainties regarding the implementation or if feedback is sought for any aspect of the changes, please feel free to provide input or ask questions.
![Screenshot 2024-03-27 030810](https://github.com/camicroscope/caMicroscope/assets/77133593/09a1948e-daf6-42d5-af77-96381e8cbc76)
