### PR TITLE
Added dark mode toggle button and functionality to the sign up page

### DIFF
--- a/apps/signup/signup.css
+++ b/apps/signup/signup.css
@@ -128,3 +128,68 @@ nav li:not(.active):hover a{
 		width: 300px;
 	}
 }
+
+This codes styles the dark mode the light/mode icon */
+
+
+#toggle-icon{
+	position: fixed;
+	background-color: red !important;
+
+   }
+
+  #toggle-icon.fa-moon {
+	color: #808080;
+	cursor: pointer;
+	background-color: #4a719b;
+	border-radius: 50%;
+	padding: 0.4rem;
+
+  }
+
+  #toggle-icon.fa-sun {
+	color: rgb(190, 190, 44);
+	cursor: pointer;
+	background-color: #4a719b;
+	border-radius: 50%;
+	padding: 0.4rem;
+  }
+
+  .dark-mode {
+	background-color:  #212529;
+	color: white;
+  }
+
+  .navdarkmode{
+	background-color: black !important ;
+   }
+
+  .p-color {
+	color: white;
+  }
+
+  .h2-color,
+  .h3-color {
+	color: rgb(173, 191, 214);
+  }
+
+  a.button.content-buttoncolor {
+	color: white;
+	border:0.4px solid white;
+
+  }
+
+  .bg-whiteslide{
+  background-color: black !important;
+  border-color: black !important;
+  color: white !important;
+  }
+
+  .modal-content-dark{
+	background-color:  #212529 !important;
+  }
+
+  #userForm.signup-form-dark{
+	background-color:  #17191c !important;
+	border: none;
+  }

--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -25,6 +25,48 @@
     src="https://code.jquery.com/jquery-3.4.1.min.js"
     integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo="
     crossorigin="anonymous"></script>
+    <script>
+
+      // Dark mode functionality
+      function toggleTheme() {
+        // Get the icon element
+        const icon = document.getElementById("toggle-icon");
+        const contentsButton = document.querySelectorAll(".button");
+        const paragraphs = document.querySelectorAll("p");
+        const heading2 = document.querySelectorAll("h2");
+        const heading3 = document.querySelectorAll("h3");
+        const navdarkmode = document.querySelectorAll(".bg-dark");
+        const signupForm = document.querySelector('#userForm');
+  
+        // Toggle dark mode class on body
+        document.body.classList.toggle("dark-mode");
+  
+        // Toggle custom color class on  elements
+        paragraphs.forEach((p) => p.classList.toggle("p-color"));
+        heading2.forEach((h2) => h2.classList.toggle("h2-color"));
+        heading3.forEach((h3) => h3.classList.toggle("h3-color"));
+        contentsButton.forEach((button) =>
+          button.classList.toggle("content-buttoncolor")
+        );
+       navdarkmode.forEach((navmode) =>
+          navmode.classList.toggle("navdarkmode")
+        );
+        signupForm.classList.toggle("signup-form-dark")
+  
+  
+        // Toggle dark class on the icon
+        if (icon.classList.contains("fa-sun")) {
+          icon.classList.remove("fa-sun");
+          icon.classList.add("fa-moon");
+        } else {
+          icon.classList.remove("fa-moon");
+          icon.classList.add("fa-sun");
+        }
+      }
+  
+  
+      </script>
+  
     
 
 
@@ -35,7 +77,7 @@
 
   <body>
 
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
+    <nav class="navbar navbar-expand-lg  navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
       <div class="container-fluid">
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
@@ -59,6 +101,7 @@
                   </ul>
               </div>
       </div>
+      <i id="toggle-icon" class="fas fa-sun " style="margin-right: 1em;" onclick="toggleTheme()"></i>
   </nav>
 
     <div class="signup-form">
@@ -77,7 +120,7 @@
         <div class="form-group">
           <div class="input-group">
             <span class="input-group-addon"><i class="fa fa-envelope" style="margin-top: 0.5em;"></i></span>
-            <input id="mail" type="email" class="form-control" name="email" placeholder="Email" required="required">
+            <input id="mail" type="email" class="form-control" name="email" placeholder="Email" required="required" style="margin-left: 1em;">
           </div>
         </div>
         <br>
@@ -85,7 +128,7 @@
           <div class="input-group">
             <span class="input-group-addon"><i class="fa fa-th-list" style="margin-top: 0.5em;"></i></span>
             <input type="text" id="filters" class="form-control" placeholder="['list','of','filters']"
-              required="required">
+              required="required"  style="margin-left: 1em;">
           </div>
         </div> <br>
 


### PR DESCRIPTION
Summary
In this contribution, I've integrated dark mode functionality into the SignUp page, providing users with the option to toggle between dark and light modes seamlessly. This enhancement aims to improve the visual experience during the SignUp process and accommodate user preferences for a darker interface.

Motivation
The motivation behind this pull request is to enhance my SignUp page's usability and cater to users' diverse preferences. By introducing dark mode, I aim to reduce eye strain and enhance readability, particularly for users accessing the SignUp page in low-light environments. This feature underscores my commitment to continuously improving user experience and accessibility across my application.

Testing
I conducted thorough manual testing to ensure the successful implementation of dark mode on the SignUp page. Testing involved validating the toggle's functionality across different browsers and devices to ensure a consistent user experience. By rigorously testing this feature, I aim to ensure its reliability and effectiveness in enhancing user experience.

![Screenshot 2024-03-27 034640](https://github.com/camicroscope/caMicroscope/assets/77133593/61cc87fa-6b74-48b4-880f-6f3478a8b65a)
![Screenshot 2024-03-27 034610](https://github.com/camicroscope/caMicroscope/assets/77133593/806dc45e-238c-4600-a8a2-351eaf825a38)


