### PR TITLE
 Copyright year added to the landing page footer that updates automatically

### DIFF
--- a/apps/landing/landing.html
+++ b/apps/landing/landing.html
@@ -121,6 +121,7 @@
             <section class="about" style="margin-left:0cm">
 
                 U24 CA18092401A1, <b>Tools to Analyze Morphology and Spatially Mapped Molecular Data</b>
+                <p class="p " style="color: black;">Copyright ©<span id = "current-year" style="color: black;" ></span> caMicroscope</p>
             </section>
 
 
@@ -129,6 +130,13 @@
     </div>
 
 </footer>
+<script>
+    // Update footer date automatically
+    const currentYear = new Date().getFullYear();
+    document.getElementById("current-year").textContent = currentYear;
+
+
+</script>
 
 
 


### PR DESCRIPTION


Summary
I have added a function to the landing page footer that automatically updates the copyright year annually. This ensures that the displayed year remains accurate without manual intervention.

Motivation
The motivation behind this pull request is to enhance the professionalism and reliability of our landing page. By implementing this automatic year update functionality, I aim to ensure that the copyright year displayed in the footer is always current, reflecting our commitment to providing up-to-date content to our users.

Testing
I conducted thorough testing to verify the functionality of the automatic year update feature. This included testing various scenarios and edge cases to ensure that the year updates correctly every 365 or 366 days, depending on leap years. By rigorously testing this feature, I aim to ensure its accuracy and reliability in keeping our landing page content current.

![Screenshot 2024-03-27 035626](https://github.com/camicroscope/caMicroscope/assets/77133593/3f9e893d-8380-4a05-8b44-793f6a8dd003)
