### PR TITLE
Work bench function duplicated button removed

### DIFF
--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -347,13 +347,7 @@
                       accept=".zip"
                       required
                     />
-                    <label
-                      class="custom-file-label labelsInputLabel"
-                      for="labelsInput"
-                      style="overflow: hidden;"
-                    >
-                      Choose
-                    </label>
+                   
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Summary
This pull request aims to delete the duplicated "choose" button in the caM slide button located in the "Select caMircoscope labeling files" section of the workbench page.

Motivation
The motivation behind this change is to remove redundancy and improve the clarity and consistency of the user interface. By eliminating the duplicated button, we can enhance the usability of the page and provide a more streamlined experience for users.

Testing
Testing has been performed to ensure that the removal of the duplicated button does not impact the functionality of the caM slide button. Manual testing has been conducted to verify that users can still select caMircoscope labelling files without any issues.

Questions
I do not have any specific questions regarding this change. However, feedback on the UI improvement and suggestions for further enhancements are welcome.

BEFORE
![Screenshot 2024-03-27 050833](https://github.com/camicroscope/caMicroscope/assets/77133593/a47b3f2a-ad14-4371-b8f4-ff8655ceac19)

AFTER
![Screenshot 2024-03-27 050945](https://github.com/camicroscope/caMicroscope/assets/77133593/7aacfb79-015d-4599-be17-8994a19989a7)
