### PR TITLE
Duplicated text deleted

### DIFF
--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -258,12 +258,7 @@
                   accept=".zip"
                   style="max-width: 98%;"
                 />
-                <label
-                  style="overflow: hidden;"
-                  class="custom-file-label spriteInputLabel"
-                  for="spriteInput"
-                  >Choose file
-                </label>
+                
               </div>
             </div>
           </div>


### PR DESCRIPTION
This pull request removes the "Choose file" label from the "Select your dataset" section of the workbench page. The section already contains an input element with a type property of "file," making the additional "Choose file" text redundant.

Motivation
The motivation behind this change is to improve the visual clarity and consistency of the user interface. Removing the duplicated "Choose file" label enhances the aesthetics of the section and eliminates unnecessary repetition, resulting in a cleaner and more streamlined design.

Testing
Testing has been conducted to ensure that the removal of the "Choose file" label does not impact the functionality of the input element. Manual testing has been performed to verify that users can still select their dataset files without any issues after the label has been removed.

BEFORE
![314056663-f3794465-eec8-47c4-88fd-73bd2d79bc88](https://github.com/camicroscope/caMicroscope/assets/77133593/b3e9e8e2-7ef7-4e43-bcfa-cf7728956151)

AFTER
![314056732-d73df49a-835e-4930-8cd2-9ee1f2b92cb0](https://github.com/camicroscope/caMicroscope/assets/77133593/cd1d36b7-b729-4095-8ffa-013b37673349)
