### PR TITLE
 Help section duplicated close button resolved

### DIFF
--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -463,14 +463,7 @@
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="helpModalTitle">Help - User Guide</h5>
-            <button
-              type="button"
-              class="close"
-              data-dismiss="modal"
-              aria-label="Close"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
+            
           </div>
           <div class="modal-body" style="align-content: center;"></div>
           <div class="modal-footer">


### PR DESCRIPTION
Summary
This pull request removes the duplicated "close" button from the "Help user guide" section. The section previously contained both a "fa times" button and a "close" button, which served the same purpose. The "fa times" button has been removed to avoid redundancy and streamline the UI.

Motivation
The motivation behind this change is to enhance the clarity and simplicity of the user interface. Removing the duplicated "close" button ensures consistency and eliminates unnecessary repetition, resulting in a more user-friendly experience.

Testing
Testing has been conducted to ensure that the removal of the "fa times" button does not affect the functionality of the "close" button. Manual testing has been performed to verify that users can still close the "Help user guide" section without any issues after the button has been removed.

Questions
I do not have any specific questions regarding this change. However, feedback on the UI improvement and suggestions for further enhancements are welcome.

BEFORE
![314064509-db1ff0a1-5c30-415e-a142-b173c8868616](https://github.com/camicroscope/caMicroscope/assets/77133593/3115e0be-933c-440d-95b3-90ab3781d48e)

AFTER
![314064599-19befa59-a06a-4663-9ec6-dc727374a8fd](https://github.com/camicroscope/caMicroscope/assets/77133593/c37c358d-1885-4afd-92c6-2dad1c4d609d)
