### PR TITLE
Repetative message and Paragraph spacing bug Fixed

### DIFF
--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -245,10 +245,11 @@
             <!-- Title -->
             <h4 class="card-title">Select your dataset</h4>
             <!-- Text -->
-            <p style="text-align: justify;" class="card-text">
+            <p style="text-align: left;" class="card-text">
               Select the dataset (.zip) having three files; spritesheet
               (data.jpg), a binary labels (labels.bin) and the classes
               (labelnames.csv) from your local storage.
+              
             </p>
             <div class="input-group">
               <div class="custom-file">
@@ -262,7 +263,7 @@
                   style="overflow: hidden;"
                   class="custom-file-label spriteInputLabel"
                   for="spriteInput"
-                  >Choose file
+                  >
                 </label>
               </div>
             </div>
@@ -352,7 +353,7 @@
                       for="labelsInput"
                       style="overflow: hidden;"
                     >
-                      Choose
+                     
                     </label>
                   </div>
                 </div>


### PR DESCRIPTION

## Summary
Upon accessing the Workbench page, users encounter repetitive information on the screen as shown in **[issue](https://github.com/camicroscope/caMicroscope/issues/892)** and notice unnecessary spacing within paragraphs. 

## Motivation
The motivation to address this issue stems from the desire to enhance user experience and usability. Repetitive information and excessive spacing can confuse users, leading to frustration and a poor overall impression of the platform.

## Testing
Done manually

## Screenshot
**Before**
![11](https://github.com/camicroscope/caMicroscope/assets/66128370/3785e992-b8be-4568-bfb8-a0782194f78b)
![1](https://github.com/camicroscope/caMicroscope/assets/66128370/53cbbcbf-6be9-429e-91b3-df977c3075b9)
![2](https://github.com/camicroscope/caMicroscope/assets/66128370/b6994ed8-ab90-4dd6-9447-97cb8d7a8570)
![3](https://github.com/camicroscope/caMicroscope/assets/66128370/73d2cf91-142c-41f3-9904-4a849a53cc16)
**After**
![A1](https://github.com/camicroscope/caMicroscope/assets/66128370/ae6d9768-c9a5-43bc-9929-38a4b8278c32)
![A2](https://github.com/camicroscope/caMicroscope/assets/66128370/301d7519-ad53-41d9-87eb-648b1530c4e2)
![A4](https://github.com/camicroscope/caMicroscope/assets/66128370/dc8d5e60-a571-45d0-98a8-944ea28f4a03)



