### PR TITLE
Fix UI Issue: Duplicated Buttons on 'Help/User Guide' Selection

### DIFF
--- a/apps/dev-workbench/workbench.html
+++ b/apps/dev-workbench/workbench.html
@@ -463,14 +463,14 @@
         <div class="modal-content">
           <div class="modal-header">
             <h5 class="modal-title" id="helpModalTitle">Help - User Guide</h5>
-            <button
+            <!-- <button
               type="button"
               class="close"
               data-dismiss="modal"
               aria-label="Close"
             >
               <span aria-hidden="true">&times;</span>
-            </button>
+            </button> -->
           </div>
           <div class="modal-body" style="align-content: center;"></div>
           <div class="modal-footer">


### PR DESCRIPTION

## Summary
The [issue ](https://github.com/camicroscope/caMicroscope/issues/894)of duplicated buttons when selecting the "Help/User Guide" option on the Workbench page has been resolved. Now, upon selecting the "Help/User Guide" option, the message and button is displayed correctly without duplication, ensuring a clear and professional user interface.

## Motivation
This pull request addresses the reported bug by fixing the duplication of buttons, which detracted from the professionalism and usability of the UI.

## Testing
Testing done manually

## Screenshot
_before_

https://github.com/camicroscope/caMicroscope/assets/66128370/49394c1b-b642-4673-a5b5-6d1379a65479

_After_

https://github.com/camicroscope/caMicroscope/assets/66128370/2fae9966-2d73-42b0-903a-ac4431e3a9e2

