### PR TITLE
Fixed disabled zooming in mobile view

### DIFF
--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -5,7 +5,7 @@
     <meta name="keywords" content="camicroscope, quip" />
     <meta charset='utf-8'>
     <meta http-equiv='X-UA-Compatible' content='IE=edge'>
-    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+    <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=2.0'>
     <title>CaMicroscope - User Signup</title>
 
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">

--- a/apps/table.html
+++ b/apps/table.html
@@ -6,7 +6,7 @@
 	<meta charset='utf-8'>
 	<meta http-equiv='X-UA-Compatible' content='IE=edge'>
 	<meta name='viewport'
-		content='width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+		content='width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=2.0'>
 	<!-- common -->
 	<link rel='stylesheet' type='text/css' media='all' href='./common.css'/>
 	<!-- Check If we're logged in ok, otherwise, log in for us -->


### PR DESCRIPTION
## Summary
Removed the user-scalable="no" parameter from the content attribute to allow zooming.
Add maximum-scale=2.0 to allow sufficient zooming.

## Motivation
This PR fixes #830 
