### PR TITLE
Saving Marks Should Include User's X, Y, Zoom, etc #844

### DIFF
--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -260,9 +260,9 @@ function initCore() {
 
             const states = StatesHelper.getCurrentStates(isImageCoordinate = true);
             if (!states) return;
-            attributes.X = states.x
-            attributes.Y = states.y
-            attributes.zoom = states.z
+            attributes.X = states.x;
+            attributes.Y = states.y;
+            attributes.zoom = states.z;
 
             body = convertHumanAnnotationToPopupBody(attributes);
             if (

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -223,7 +223,6 @@ function initCore() {
         // for support QUIP 2.0
         const data = Array.isArray(e.data) ? e.data[e.data.selected] : e.data;
 
-        console.log("data", Array.isArray(e.data),data, e.data, e.data[e.data.selected]);
         const type = data.provenance.analysis.source;
         let body;
         let attributes;
@@ -347,7 +346,6 @@ function initCore() {
               dataCopy.geometries,
           );
         }
-        console.log("abc",$CAMIC.viewer);
         editAnnoCallback(id, slide, dataCopy);
       });
 

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -223,6 +223,7 @@ function initCore() {
         // for support QUIP 2.0
         const data = Array.isArray(e.data) ? e.data[e.data.selected] : e.data;
 
+        console.log("data", Array.isArray(e.data),data, e.data, e.data[e.data.selected]);
         const type = data.provenance.analysis.source;
         let body;
         let attributes;
@@ -257,6 +258,13 @@ function initCore() {
             attributes = data.properties.annotations;
             if (area) attributes.area = area;
             if (circumference) attributes.circumference = circumference;
+
+            const states = StatesHelper.getCurrentStates(isImageCoordinate = false);
+            if (!states) return;
+            attributes.X = states.x
+            attributes.Y = states.y
+            attributes.zoom = states.z
+            
             body = convertHumanAnnotationToPopupBody(attributes);
             if (
               data.geometries &&
@@ -339,6 +347,7 @@ function initCore() {
               dataCopy.geometries,
           );
         }
+        console.log("abc",$CAMIC.viewer);
         editAnnoCallback(id, slide, dataCopy);
       });
 

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -247,7 +247,7 @@ function initCore() {
                 data.geometries.features[data.selected] &&
                 data.geometries.features[data.selected].properties.circumference
               ) {
-                circumference = `${Math.round(
+                circumference = `${Math. round(
                     data.geometries.features[data.selected].properties
                         .circumference,
                 )} μm`;
@@ -259,12 +259,12 @@ function initCore() {
             if (area) attributes.area = area;
             if (circumference) attributes.circumference = circumference;
 
-            const states = StatesHelper.getCurrentStates(isImageCoordinate = false);
+            const states = StatesHelper.getCurrentStates(isImageCoordinate = true);
             if (!states) return;
             attributes.X = states.x
             attributes.Y = states.y
             attributes.zoom = states.z
-            
+
             body = convertHumanAnnotationToPopupBody(attributes);
             if (
               data.geometries &&

--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -246,7 +246,7 @@ function initCore() {
                 data.geometries.features[data.selected] &&
                 data.geometries.features[data.selected].properties.circumference
               ) {
-                circumference = `${Math. round(
+                circumference = `${Math.round(
                     data.geometries.features[data.selected].properties
                         .circumference,
                 )} μm`;


### PR DESCRIPTION
## Summary
Added X, Y (image coordinate ）and zoom to the pop-panel
## Motivation
Because until now, it was not possible to check the image coordinate and zooming information of the area annotated in mouse mode.

## Testing
Before
![Before_X_Y_Z](https://github.com/camicroscope/caMicroscope/assets/134823240/d917f932-e815-48f0-9646-ffb839d42fa9)
After
![After_X_Y_Z](https://github.com/camicroscope/caMicroscope/assets/134823240/9d0fd28f-d940-40c5-a674-f39070e2db7b)

## Questions
please check whether my PR matches your issue #844 or not.


