### PR TITLE
Added Aria Labels to Image Links

### DIFF
--- a/apps/landing/landing.html
+++ b/apps/landing/landing.html
@@ -81,13 +81,13 @@
 
         <div class="content">
             <p>caMicroscope is a tool to view, annotate, and analyze biomedical images.</p>
-            <a href="#" class="image fit"><img src="./banner1.jpg" alt="" /></a>
+            <a href="#" class="image fit" aria-label="Reload Home Page"><img src="./banner1.jpg" alt="" /></a>
 
         </div>
 
         <div class="posts" style="margin-top: 5em;">
             <section class="post">
-                <a href="../table.html" class="image"><img src="./camic.jpg" alt=""/></a>
+                <a href="../table.html" class="image" aria-label="Visit Slides Page"><img src="./camic.jpg" alt=""/></a>
                 <div class="content">
                     <h3>caMicroscope</h3>
                     <p>Use camicroscope to explore and mark slides uploaded. If this is a restricted access deployment, you will be prompted to log in here.</p>
@@ -95,7 +95,7 @@
                 </div>
             </section>
             <section class="post">
-                <a target="_blank" href="https://camicroscope.github.io/docs/" class="image"><img src="./code.jpg" alt=""/></a>
+                <a target="_blank" href="https://camicroscope.github.io/docs/" class="image" aria-label="Visit Documentation Page"><img src="./code.jpg" alt=""/></a>
                 <div class="content">
                     <h3>Documentation</h3>
                     <p>Read documentation for using and developing caMicroscope.</p>


### PR DESCRIPTION
I added aria labels to the images (which also happen to be links) on the home page. Those images didn't initially have aria labels which posed an accessibility issue for users who use only keyboards to navigate the site.

## Motivation
This PR fixed #901 
