### PR TITLE
Feat: darkmode icon and funtionality added to the export html page

### DIFF
--- a/apps/port/export.css
+++ b/apps/port/export.css
@@ -1,0 +1,70 @@
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css');
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:300italic,700italic,700,300");
+
+
+
+ /* This codes styles the dark mode the light/mode icon  */
+
+
+ #toggle-icon{
+    position: fixed;
+     right: 3%;	
+     top:2.4%;
+     z-index: 999999;
+    
+   } 
+  
+    #toggle-icon.fa-moon {
+    color: #808080;
+    cursor: pointer;
+    background-color: #4a719b;
+    border-radius: 50%;
+    padding: 0.4rem;
+  
+
+  }
+  
+  #toggle-icon.fa-sun {
+    color: rgb(190, 190, 44);
+    cursor: pointer;
+    background-color: #4a719b;
+    border-radius: 50%;
+    padding: 0.4rem;
+
+  
+  }
+  
+  .dark-mode {
+    background-color:  #212529;
+    color: white;
+  }
+  
+  .darkmovenav{
+    background-color: black !important ;
+   }
+  
+  .p-color {
+    color: white;
+  }
+  
+  .h2-color,
+  .h3-color {
+    color: rgb(173, 191, 214);
+  }
+  
+  a.button.content-buttoncolor {
+    color: white;
+    border:0.4px solid white;
+  
+  }
+  
+  .bg-whiteslide{
+  background-color: black !important;
+  border-color: black !important;
+  color: white !important;
+  }
+  
+  .modal-content-dark{
+    background-color:  #212529 !important;
+  }
+  

--- a/apps/port/export.html
+++ b/apps/port/export.html
@@ -3,12 +3,17 @@
 <head>
   <script src="../../core/Store.js"></script>
   <title>Export Results [caMicroscope]</title>
+  <link rel="stylesheet" href="export.css">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT" crossorigin="anonymous">
   <style>
     #exportTitle{
+    
       background-color: #17a2b8 !important;
       color: white;
+      justify-items: center;
     }
+
+    
     #output{
       padding: 20px;
     }
@@ -23,11 +28,53 @@
       background-color: #0d6efd;
       border-color: #0d6efd;
     }
+
+
     </style>
+    <script>
+      // Dark mode functionality
+        
+              function toggleTheme() {
+            // Get the icon element
+            const icon = document.getElementById('toggle-icon');
+            const contentsButton = document.querySelectorAll('.button');
+            const paragraphs = document.querySelectorAll('p');
+            const heading2 = document.querySelectorAll('h2');
+            const heading3 = document.querySelectorAll('h3');
+            const navdarkmode = document.querySelector('.bg-dark');
+        
+            // Toggle dark mode class on body
+            document.body.classList.toggle("dark-mode");
+        
+        
+        
+            // Toggle custom color class on  elements
+            paragraphs.forEach(p => p.classList.toggle("p-color"));
+            heading2.forEach(h2 => h2.classList.toggle("h2-color"));
+            heading3.forEach(h3 => h3.classList.toggle("h3-color"));
+            contentsButton.forEach(button => button.classList.toggle("content-buttoncolor"));
+             navdarkmode.classList.toggle("darkmovenav");
+
+        
+            // Toggle dark class on the icon
+            if (icon.classList.contains("fa-sun")) {
+                icon.classList.remove("fa-sun");
+                icon.classList.add("fa-moon");
+            } else {
+                icon.classList.remove("fa-moon");
+                icon.classList.add("fa-sun");
+            }
+         }
+    
+            </script>
+   
 </head>
 <body>
 
-  <h1 class="text-center py-5" id="exportTitle">Export Results</h1>
+ <div class=" text-center py-5" id="exportTitle">
+  <h1 >Export Results</h1>
+  <i id="toggle-icon" class= "fas fa-moon" onclick="toggleTheme()"></i>
+ </div>
   <div class="form text-center my-5">
   <label for="slide_id">Slide Ids (exact matches, comma delimited):</label>
   <input type="text" class="mx-1" id="slide_id" name="slide_id">
@@ -39,6 +86,8 @@
     <div id="output"></div>
     <button id="convert_btn" onclick="downloadResults()" type="button" class="btn btn-primary my-3">Download Selected Results</button>
   </div>
+   
+    
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-u1OknCvxWvY5kfmNBILK2hRnQC3Pr17a+RTT6rIHI7NnikvbZlHgTPOOmMi466C8" crossorigin="anonymous"></script>
   <script src="//code.jquery.com/jquery.min.js"></script>
   <script src="./tree_table.js"></script>


### PR DESCRIPTION
Contribution: Dark Mode Functionality Added to Export Page
Summary
This pull request introduces dark mode functionality to the Export page, providing users with the option to switch between dark and light modes seamlessly.

Motivation
The motivation behind this change is to enhance user experience on the Export page by offering a dark mode option. Dark mode reduces eye strain and provides a comfortable viewing experience, particularly in low-light environments. By adding this feature, we aim to cater to diverse user preferences and improve overall usability.

Testing
Extensive testing has been conducted to ensure the smooth integration of dark mode functionality. This includes testing the toggle switch across different browsers and devices to ensure consistent behavior and appearance. Additionally, user feedback has been gathered to validate the effectiveness of the dark mode feature and ensure it meets user expectations.

![Screenshot 2024-03-29 231333](https://github.com/camicroscope/caMicroscope/assets/77133593/267dd3d8-e0a9-4a0a-ae52-209f2ade595c)
![Screenshot 2024-03-29 195032](https://github.com/camicroscope/caMicroscope/assets/77133593/f3584ecc-9917-46c2-a9ca-badbe98b090a)
