### PR TITLE
Adjusted the segment Html page in compliance to W3C standards

### DIFF
--- a/apps/segment/segment.html
+++ b/apps/segment/segment.html
@@ -65,88 +65,88 @@
    </script>
 
    <!-- opencv.js -->
-   <script type='text/javascript' src='./opencv.js'></script>
+   <script  src='./opencv.js'></script>
    <!-- tensorflow.js -->
-   <script type='text/javascript' src='../../common/tf.min.js'></script>
+   <script src='../../common/tf.min.js'></script>
    <!-- tfjs visulisation -->
-   <script type='text/javascript' src='../../common/tfjs-vis.min.js'></script>
+   <script  src='../../common/tfjs-vis.min.js'></script>
    <!--  common js START -->
    <!-- util.js -->
-  <script type='text/javascript' src='../../common/util.js'></script>
-  <script type='text/javascript' src='../../common/DrawHelper.js'></script>
-  <script type='text/javascript' src='../../common/simplify.js'></script>
-  <script type='text/javascript' src='../../common/paths.js'></script>
+  <script  src='../../common/util.js'></script>
+  <script  src='../../common/DrawHelper.js'></script>
+  <script src='../../common/simplify.js'></script>
+  <script  src='../../common/paths.js'></script>
   <!-- add pure-form script -->
-  <script type='text/javascript' src='../../common/pureform/document-register-element.js'></script>
-  <script type='text/javascript' src='../../common/pureform/pure-form.js'></script>
+  <script  src='../../common/pureform/document-register-element.js'></script>
+  <script  src='../../common/pureform/pure-form.js'></script>
   <!-- color picker js -->
-  <script type='text/javascript' src='../../common/colorpicker/color-picker.js'></script>
+  <script src='../../common/colorpicker/color-picker.js'></script>
   <!-- sortable js -->
-  <script type='text/javascript' src='../../common/sortable/Sortable.js'></script>
+  <script  src='../../common/sortable/Sortable.js'></script>
   <!-- AJV json validator engine -->
-  <script type='text/javascript' src='../../common/ajv.js'></script>
+  <script  src='../../common/ajv.js'></script>
   <!-- IDB helper -->
-  <script type='text/javascript' src='../../common/idb.js'></script>
+  <script  src='../../common/idb.js'></script>
   <!-- Color Separation -->
-  <script type='text/javascript' src='../../common/colorSeparation.js'></script>
+  <script  src='../../common/colorSeparation.js'></script>
   <!--  common js END -->
 
   <!--  components js START -->
   <!-- message display js -->
-  <script type='text/javascript' src='../../components/camessage/camessage.js'></script>
+  <script  src='../../components/camessage/camessage.js'></script>
   <!-- toolbar js -->
-  <script type='text/javascript' src='../../components/toolbar/toolbar.js'></script>
+  <script  src='../../components/toolbar/toolbar.js'></script>
   <!-- sidemenu js -->
-  <script type='text/javascript' src='../../components/sidemenu/sidemenu.js'></script>
+  <script src='../../components/sidemenu/sidemenu.js'></script>
     <!-- collapsible list js -->
-    <script type='text/javascript' src='../../components/collapsiblelist/collapsiblelist.js'></script>
+    <script src='../../components/collapsiblelist/collapsiblelist.js'></script>
   <!-- layers controller js -->
-  <script type='text/javascript' src='../../components/layersviewer/layersviewer.js'></script>
+  <script  src='../../components/layersviewer/layersviewer.js'></script>
   <!-- operation panel js -->
-  <script type='text/javascript' src='../../components/operationpanel/operationpanel.js'></script>
+  <script  src='../../components/operationpanel/operationpanel.js'></script>
   <!-- loading cover js -->
-  <script type='text/javascript' src='../../components/loading/loading.js'></script>
+  <script  src='../../components/loading/loading.js'></script>
   <!-- stylecontextmenu js -->
-  <script type='text/javascript' src='../../components/simplecontextmenu/simplecontextmenu.js'></script>
+  <script  src='../../components/simplecontextmenu/simplecontextmenu.js'></script>
   <!-- popup panel js -->
-  <script type='text/javascript' src='../../components/popuppanel/popuppanel.js'></script>
+  <script src='../../components/popuppanel/popuppanel.js'></script>
   <!-- message queue js -->
-  <script type='text/javascript' src='../../components/messagequeue/messagequeue.js'></script>
+  <script  src='../../components/messagequeue/messagequeue.js'></script>
   <!-- mult selector js -->
-  <script type='text/javascript' src='../../components/multselector/multselector.js'></script>
+  <script  src='../../components/multselector/multselector.js'></script>
   <!-- spyglass -->
-  <script type='text/javascript' src='../../components/spyglass/spyglass.js'></script>
+  <script  src='../../components/spyglass/spyglass.js'></script>
   <!-- script type='text/javascript' src='segmentpanel/slider.js'></script -->
-  <script type='text/javascript' src='./segmentpanel/segmentpanel.js'></script>
+  <script  src='./segmentpanel/segmentpanel.js'></script>
   <!-- modal box -->
-  <script type="text/javascript" src="../../components/modalbox/modalbox.js"></script>
+  <script  src="../../components/modalbox/modalbox.js"></script>
   <!--  components js END -->
 
 
   <!-- osd & core js START -->
-  <script type='text/javascript' src='../../core/openseadragon/openseadragon.js' ></script>
-  <script type='text/javascript' src='../../core/openseadragon-imaginghelper.min.js'></script>
-  <script type='text/javascript' src='../../core/openseadragon-scalebar.js'></script>
-  <script type='text/javascript' src='../../core/openseadragonzoomlevels.js'></script>
+  <script  src='../../core/openseadragon/openseadragon.js' ></script>
+  <script  src='../../core/openseadragon-imaginghelper.min.js'></script>
+  <script src='../../core/openseadragon-scalebar.js'></script>
+  <script  src='../../core/openseadragonzoomlevels.js'></script>
 
   <!-- core (package/ext) libs -->
-  <script type='text/javascript' src='../../core/StatesHelper.js'></script>
-  <script type='text/javascript' src='../../core/Validation.js'></script>
-  <script type='text/javascript' src='../../core/Store.js'></script>
-  <script type='text/javascript' src='../../core/CaMic.js'></script>
+  <script  src='../../core/StatesHelper.js'></script>
+  <script  src='../../core/Validation.js'></script>
+  <script  src='../../core/Store.js'></script>
+  <script  src='../../core/CaMic.js'></script>
 
-  <script type='text/javascript' src='../../core/extension/segment-annotation.js'></script>
-  <script type='text/javascript' src='../../core/extension/openseadragon-canvas-draw-overlay.js'></script>
-  <script type='text/javascript' src='../../core/extension/openseadragon-overlays-manage.js'></script>
-  <script type='text/javascript' src='../../core/extension/openseadragon-measurement-tool/openseadragon-measurement-tool.js'></script>
-  <script type='text/javascript' src='../../core/extension/openseadragon-zoom-control/openseadragon-zoom-control.js'></script>
+  <script  src='../../core/extension/segment-annotation.js'></script>
+  <script  src='../../core/extension/openseadragon-canvas-draw-overlay.js'></script>
+  <script  src='../../core/extension/openseadragon-overlays-manage.js'></script>
+  <script  src='../../core/extension/openseadragon-measurement-tool/openseadragon-measurement-tool.js'></script>
+  <script src='../../core/extension/openseadragon-zoom-control/openseadragon-zoom-control.js'></script>
 
 
   <!-- business js -->
-  <script type='text/javascript' src='../../common/PathdbMods.js'></script>
-  <script type='text/javascript' src='../../common/LocalStore.js'></script>
-  <script type='text/javascript' src='../../common/NanoBorbMods.js'></script>
-  <script type='text/javascript' src='../../common/dynamicLoadScript.js'></script>
+  <script  src='../../common/PathdbMods.js'></script>
+  <script  src='../../common/LocalStore.js'></script>
+  <script  src='../../common/NanoBorbMods.js'></script>
+  <script  src='../../common/dynamicLoadScript.js'></script>
   <!-- <script src="../../dist/imgbox_package.js"></script> -->
 
   <!--
@@ -156,18 +156,18 @@
   -->
 
   <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
-  <script type="text/javascript" src="//stuk.github.io/jszip/dist/jszip.js"></script>
-  <script type="text/javascript" src="//stuk.github.io/jszip-utils/dist/jszip-utils.js"></script>
-  <script type="text/javascript" src="//stuk.github.io/jszip/vendor/FileSaver.js"></script>
-  <script type='text/javascript' src='../../common/sizeof.compressed.js'></script>
+  <script  src="//stuk.github.io/jszip/dist/jszip.js"></script>
+  <script  src="//stuk.github.io/jszip-utils/dist/jszip-utils.js"></script>
+  <script  src="//stuk.github.io/jszip/vendor/FileSaver.js"></script>
+  <script  src='../../common/sizeof.compressed.js'></script>
 
   <!-- Popper & tippy -->
   <script src="https://unpkg.com/@popperjs/core@2"></script>
   <script src="https://unpkg.com/tippy.js@6"></script>
 
   <!-- Smartpen -->
-  <script type="text/javascript" src="../../common/enhance.js"></script>
-  <script type="text/javascript" src="../../common/smartpen/autoalign.js"></script>
+  <script  src="../../common/enhance.js"></script>
+  <script  src="../../common/smartpen/autoalign.js"></script>
   <link rel="stylesheet" type="text/css" media="all" href="../../common/smartpen/autoalign.css"/>
   <!-- Smartpen end -->
 
@@ -186,10 +186,9 @@
 <div id="details_panel"></div>
 <div id="popup-container"></div>
 <div id="snackbar"></div>
-</body>
 
 <script src='segment.js'></script>
-<script type="text/javascript">
+<script >
     if(detectIE()){
       createWarningText('You are using an <strong>IE/Edge</strong> browser that may be lead to erratic behavior on caMicroscope. Please switch to <a href="https://www.google.com/chrome/">Chrome</a>, <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a> or <a href="https://www.apple.com/safari/">Safari</a> browser to improve your experience.');
     }
@@ -233,4 +232,7 @@
     if($D.params.states)
       $D.params.states = StatesHelper.decodeStates($D.params.states);
 </script>
+</body>
+
+
 </html>


### PR DESCRIPTION
Summary
I made the following changes to improve compliance with W3C standards:

Removed the unnecessary type attribute from <script> tags.
Moved two <script> tag from an inappropriate location outside the head and body tags to the appropriate location inside the body tags.

Motivation
The motivation behind these changes is to adhere to best practices outlined by the W3C standards for HTML documents. According to W3C recommendations, the type attribute for <script> tags is not necessary and its omission helps reduce redundancy and clutter in the HTML markup. Additionally, placing <script> tags outside the head and body does not comply with organization and adherence to the recommended structure of HTML documents.

Testing
These changes have been tested locally to ensure that they do not adversely affect the functionality or layout of the webpage. Additionally, the updated HTML markup has been validated using online HTML validation tools to confirm compliance with W3C standards.

