### PR TITLE
Labelling html updated to W3C standards

### DIFF
--- a/apps/labeling/labeling.html
+++ b/apps/labeling/labeling.html
@@ -37,57 +37,57 @@
     </script>
 
 		<!-- message queue js -->
-		<script type='text/javascript' src='../../components/messagequeue/messagequeue.js'></script>
-		<script type='text/javascript' src='../../components/camessage/camessage.js'></script>
-		<script type='text/javascript' src='../../components/loading/loading.js' ></script>
-		<script type='text/javascript' src='../../components/toolbar/toolbar.js' ></script>
+		<script src='../../components/messagequeue/messagequeue.js'></script>
+		<script src='../../components/camessage/camessage.js'></script>
+		<script  src='../../components/loading/loading.js' ></script>
+		<script src='../../components/toolbar/toolbar.js' ></script>
 		<!-- modalbox -->
-		<script type='text/javascript' src='../../components/modalbox/modalbox.js'></script>
-		<script type='text/javascript' src='../../common/colorpicker/color-picker.js' ></script>
-		<script type='text/javascript' src='../../common/FileSaver.min.js' ></script>
-		<script type='text/javascript' src='../../common/jszip.min.js' ></script>
+		<script  src='../../components/modalbox/modalbox.js'></script>
+		<script  src='../../common/colorpicker/color-picker.js' ></script>
+		<script  src='../../common/FileSaver.min.js' ></script>
+		<script  src='../../common/jszip.min.js' ></script>
 		<!-- open seadragon lib-->
-		<script type='text/javascript' src='../../core/openseadragon/openseadragon.js' ></script>
-		<script type='text/javascript' src='../../core/openseadragon-imaginghelper.min.js'></script>
-		<script type='text/javascript' src='../../core/openseadragon-scalebar.js'></script>
-		<script type='text/javascript' src='../../core/openseadragonzoomlevels.js'></script>
+		<script  src='../../core/openseadragon/openseadragon.js' ></script>
+		<script src='../../core/openseadragon-imaginghelper.min.js'></script>
+		<script  src='../../core/openseadragon-scalebar.js'></script>
+		<script  src='../../core/openseadragonzoomlevels.js'></script>
 
 		<!-- util.js -->
-		<script type='text/javascript' src='../../common/util.js'></script>
+		<script  src='../../common/util.js'></script>
 		<!-- core (package/ext) libs -->
-		<script type='text/javascript' src='../../common/DrawHelper.js'></script>
-		<script type='text/javascript' src='../../common/simplify.js'></script>
-		<script type='text/javascript' src='../../common/paths.js'></script>
-		<script type='text/javascript' src='../../common/ajv.js'></script>
+		<script  src='../../common/DrawHelper.js'></script>
+		<script src='../../common/simplify.js'></script>
+		<script  src='../../common/paths.js'></script>
+		<script  src='../../common/ajv.js'></script>
 		<!-- IDB helper -->
-		<script type='text/javascript' src='../../common/idb.js'></script>
-		<script type='text/javascript' src='../../core/StatesHelper.js'></script>
-		<script type='text/javascript' src='../../core/Validation.js'></script>
-		<script type='text/javascript' src='../../core/Store.js'></script>
-		<script type='text/javascript' src='../../core/CaMic.js'></script>
-		<script type='text/javascript' src='../../core/extension/openseadragon-canvas-draw-overlay.js'></script>
-		<script type='text/javascript' src='../../core/extension/openseadragon-overlays-manage.js'></script>
-		<script type='text/javascript' src='../../core/extension/openseadragon-measurement-tool/openseadragon-measurement-tool.js'></script>
-		<script type='text/javascript' src='../../core/extension/openseadragon-zoom-control/openseadragon-zoom-control.js'></script>
-		<script type='text/javascript' src='../../core/extension/openseadragon-labeling/openseadragon-labeling.js'></script>
+		<script  src='../../common/idb.js'></script>
+		<script  src='../../core/StatesHelper.js'></script>
+		<script  src='../../core/Validation.js'></script>
+		<script src='../../core/Store.js'></script>
+		<script src='../../core/CaMic.js'></script>
+		<script  src='../../core/extension/openseadragon-canvas-draw-overlay.js'></script>
+		<script  src='../../core/extension/openseadragon-overlays-manage.js'></script>
+		<script  src='../../core/extension/openseadragon-measurement-tool/openseadragon-measurement-tool.js'></script>
+		<script src='../../core/extension/openseadragon-zoom-control/openseadragon-zoom-control.js'></script>
+		<script  src='../../core/extension/openseadragon-labeling/openseadragon-labeling.js'></script>
 		<!-- init data -->
 
 		<!-- ods js -->
 		<!-- <script src='./js/uicallbacks.js'></script> -->
 		<!-- <script src='./js/dataloaders.js'></script> -->
-		<script type='text/javascript' src='../../common/PathdbMods.js'></script>
-		<script type='text/javascript' src='../../common/LocalStore.js'></script>
-		<script type='text/javascript' src='../../common/NanoBorbMods.js'></script>
-		<script type='text/javascript' src='../../common/dynamicLoadScript.js'></script>
-		<script type='text/javascript' src='./labeling.js'></script>
+		<script  src='../../common/PathdbMods.js'></script>
+		<script  src='../../common/LocalStore.js'></script>
+		<script  src='../../common/NanoBorbMods.js'></script>
+		<script  src='../../common/dynamicLoadScript.js'></script>
+		<script src='./labeling.js'></script>
 
 		<!-- Popper & tippy -->
     <script src="https://unpkg.com/@popperjs/core@2"></script>
     <script src="https://unpkg.com/tippy.js@6"></script>
 
 		<!-- Smartpen -->
-	  <script type="text/javascript" src="../../common/enhance.js"></script>
-	  <script type="text/javascript" src="../../common/smartpen/autoalign.js"></script>
+	  <script  src="../../common/enhance.js"></script>
+	  <script src="../../common/smartpen/autoalign.js"></script>
 		<link rel="stylesheet" type="text/css" media="all" href="../../common/smartpen/autoalign.css"/>
 		<!-- Smartpen end -->
 		
@@ -99,50 +99,52 @@
 		<div id = 'ca_tools'></div>
 		<div id='modalbox'></div>
 		<div id ='main_viewer' class='main'></div>
+
+		<script type="text/javascript">
+			if(detectIE()){
+				createWarningText('You are using an <strong>IE/Edge</strong> browser that may be lead to erratic behavior on caMicroscope. Please switch to <a href="https://www.google.com/chrome/">Chrome</a>, <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a> or <a href="https://www.apple.com/safari/">Safari</a> browser to improve your experience.');
+			}
+	
+			Loading.open(document.body, 'CaMicroscope Is Initializing...');
+			// get slide id from url
+			const url = new URL(window.location.href);
+			$D.params = getUrlVars();
+	
+			// no slide Id error
+			if($D.params && $D.params.slideId){
+				// normal initialization starts
+				document.addEventListener('DOMContentLoaded', initialize);
+			}else if ($D.params && ($D.params.slide || $D.params.specimen ||$D.params.study || $D.params.location)){
+				let STORE = new Store()
+				STORE.findSlide($D.params.slide, $D.params.study, $D.params.specimen, $D.params.location).then(x=>{
+					let offset = parseInt($D.params.offset,10) || 0;
+					if(x.length == 0 || offset >= x.length){
+						redirect($D.pages.table,'No Slide Found. Redirecting To Table.');
+					} else {
+						newParams = $D.params
+						delete newParams.data
+						delete newParams.slide
+						delete newParams.location
+						delete newParams.offset
+						newParams.slideId = x[offset]['_id']['$oid']
+						newUrl = window.location.href.split("?")[0] + "?" + objToParamStr(newParams)
+						window.location.href = newUrl
+					}
+				}).catch(e=>{
+					console.warn(e)
+					redirect($D.pages.table,'Redirecting To Table.');
+				})
+				// find the associated slideID
+				// open viewer with that slideID
+			}else{
+				redirect($D.pages.table,'Slide Id Is Undefined. Redirecting To Flex Table.');
+			}
+	
+			// get states parameters
+			if($D.params.states){
+				$D.params.states = StatesHelper.decodeStates($D.params.states);
+			}
+		</script>
 	</body>
-	<script type="text/javascript">
-		if(detectIE()){
-			createWarningText('You are using an <strong>IE/Edge</strong> browser that may be lead to erratic behavior on caMicroscope. Please switch to <a href="https://www.google.com/chrome/">Chrome</a>, <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a> or <a href="https://www.apple.com/safari/">Safari</a> browser to improve your experience.');
-		}
-
-		Loading.open(document.body, 'CaMicroscope Is Initializing...');
-		// get slide id from url
-		const url = new URL(window.location.href);
-		$D.params = getUrlVars();
-
-		// no slide Id error
-		if($D.params && $D.params.slideId){
-			// normal initialization starts
-			document.addEventListener('DOMContentLoaded', initialize);
-		}else if ($D.params && ($D.params.slide || $D.params.specimen ||$D.params.study || $D.params.location)){
-			let STORE = new Store()
-			STORE.findSlide($D.params.slide, $D.params.study, $D.params.specimen, $D.params.location).then(x=>{
-				let offset = parseInt($D.params.offset,10) || 0;
-				if(x.length == 0 || offset >= x.length){
-					redirect($D.pages.table,'No Slide Found. Redirecting To Table.');
-				} else {
-					newParams = $D.params
-					delete newParams.data
-					delete newParams.slide
-					delete newParams.location
-					delete newParams.offset
-					newParams.slideId = x[offset]['_id']['$oid']
-					newUrl = window.location.href.split("?")[0] + "?" + objToParamStr(newParams)
-					window.location.href = newUrl
-				}
-			}).catch(e=>{
-				console.warn(e)
-				redirect($D.pages.table,'Redirecting To Table.');
-			})
-			// find the associated slideID
-			// open viewer with that slideID
-		}else{
-			redirect($D.pages.table,'Slide Id Is Undefined. Redirecting To Flex Table.');
-		}
-
-		// get states parameters
-		if($D.params.states){
-			$D.params.states = StatesHelper.decodeStates($D.params.states);
-		}
-	</script>
+	
 </html>


### PR DESCRIPTION
Summary
I made the following changes to improve compliance with W3C standards:

Removed the unnecessary type attribute from <script> tags.
Moved a <script> tag from an inappropriate location outside the head and body tags to the appropriate location inside the body tags.

Motivation
The motivation behind these changes is to adhere to best practices outlined by the W3C standards for HTML documents. According to W3C recommendations, the type attribute for <script> tags is not necessary and its omission helps reduce redundancy and clutter in the HTML markup. Additionally, placing <script> tags outside the head and body does not comply with organization and adherence to the recommended structure of HTML documents.

Testing
These changes have been tested locally to ensure that they do not adversely affect the functionality or layout of the webpage. Additionally, the updated HTML markup has been validated using online HTML validation tools to confirm compliance with W3C standards.****