### PR TITLE
Revert "Saving Marks Should Include User's X, Y, Zoom, etc #844"

### DIFF
--- a/apps/viewer/init.js
+++ b/apps/viewer/init.js
@@ -257,13 +257,6 @@ function initCore() {
             attributes = data.properties.annotations;
             if (area) attributes.area = area;
             if (circumference) attributes.circumference = circumference;
-
-            const states = StatesHelper.getCurrentStates(isImageCoordinate = true);
-            if (!states) return;
-            attributes.X = states.x;
-            attributes.Y = states.y;
-            attributes.zoom = states.z;
-
             body = convertHumanAnnotationToPopupBody(attributes);
             if (
               data.geometries &&


### PR DESCRIPTION
Reverts camicroscope/caMicroscope#902

Does not work as described, returns the current view x, y, zoom, which is not useful