### PR TITLE
add chrome driver@125 explicitly.

### DIFF
--- a/.github/workflows/axe-a11y-check.yml
+++ b/.github/workflows/axe-a11y-check.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm run build --if-present
       - run: http-server -s &
       - name: Install specific version of ChromeDriver
-        run: npm install -g chromedriver@126
+        run: npm install -g chromedriver@125
       - name: Run axe
         run: |
           npm install -g @axe-core/cli

--- a/.github/workflows/axe-a11y-check.yml
+++ b/.github/workflows/axe-a11y-check.yml
@@ -24,8 +24,10 @@ jobs:
       - run: npm install -g http-server
       - run: npm run build --if-present
       - run: http-server -s &
+      - name: Install specific version of ChromeDriver
+        run: npm install -g chromedriver@126
       - name: Run axe
         run: |
           npm install -g @axe-core/cli
           sleep 90
-          axe http://127.0.0.1:8080 --exit
+          axe http://127.0.0.1:8080 --chromedriver-path $(npm root -g)/chromedriver/bin/chromedriver --exit


### PR DESCRIPTION
On https://github.com/camicroscope/caMicroscope/actions/runs/9519258356/job/26242052785#step:8:22 noticed error ` Run npm install -g @axe-core/cli

added 84 packages in 5s

2 packages are looking for funding
  run `npm fund` for details
Running axe-core 4.9.1 in chrome-headless
Error: session not created: This version of ChromeDriver only supports Chrome version 126
Current browser version is 125.0.6422.141 with binary path /opt/google/chrome/chrome

Please install a matching version of ChromeDriver and run axe with the --chromedriver-path option:

    $ npm install -g chromedriver@<version>
    $ axe --chromedriver-path $(npm root -g)/chromedriver/bin/chromedriver <url...>

(where <version> is the first number of the "current browser version" reported above.)
Error: Process completed with exit code 2.`

Doing this to address that.