### PR TITLE
Fixed the Name Suggestion error on the Slide Viewer Page

### DIFF
--- a/common/pureform/pure-form.js
+++ b/common/pureform/pure-form.js
@@ -1851,7 +1851,7 @@
 
             // check required status
             if (!ignoreRequired && schemaItem.required && ((schemaItem.type !== 'boolean' && !value) || (Array.isArray(value) && value.length <= 0))) {
-                return 'This field must have a value';
+                return 'Please provide a name for the annotation. The name should be descriptive and unique';
             }
 
             if (schemaItem.minItems && (Array.isArray(value) && value.length < schemaItem.minItems)) {


### PR DESCRIPTION
## Summary
This PR resolves this  #1002
The part of the code where it says that the field must be a value has been changed, the change now makes it clearer to the user what the expected format is for that field

## After

![Captura de tela de 2024-07-07 22-57-28](https://github.com/camicroscope/caMicroscope/assets/66541373/643a4af7-dd4a-4119-8a82-26bad6a921e5)


