### PR TITLE
fixes #1009 : table duplication issue when screen size less than 800px

### DIFF
--- a/apps/table.js
+++ b/apps/table.js
@@ -520,8 +520,6 @@ function initialize() {
                 resetTable();
                 pageIndicatorVisible($('#datatables tbody tr').length);
               });
-              pageIndicatorVisible($('#datatables tbody tr').length);
-              resetTable();
               $('#datatables').stacktable();
               checkUserPermissions();
             });


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title -->

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
This pull request addresses an issue where the `.stacktable` components (`stacktable.small-only` and `stacktable.large-only`) were being activated simultaneously on screen sizes below 800px, causing table duplication. Additionally, it ensures that the `stacktable()` function is called only once after all table content has been fully updated to avoid redundancy or conflicts.

## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->
The issue arises from calling the `stacktable()` function multiple times when the table content changes (e.g., when pagination is applied, or the number of table entries is updated). This results in a table duplication issue when both the `.stacktable.small-only` and `.stacktable.large-only `classes are triggered at the same time on smaller screens. The goal is to ensure proper handling of table initialization and avoid unnecessary re-initializations.

## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->
Verified that the table displays correctly on both small and large screen sizes, without duplication.
Tested across various screen sizes to ensure the appropriate classes (stacktable.small-only and stacktable.large-only) are applied without overlap.

##Screenshot
![Screenshot 2024-11-14 180418](https://github.com/user-attachments/assets/56f62bf7-19a4-4cd6-8fd5-c095f25e7b53)

