### PR TITLE
[FIX] Tooltip Inaccessible on Hover in Annotation Assistant (#994)

### DIFF
--- a/components/ml-assistant/ml-assistant.js
+++ b/components/ml-assistant/ml-assistant.js
@@ -153,6 +153,11 @@ Assistant.prototype.__refreshUI = async function() {
     placement: 'left',
     delay: 300,
     theme: 'translucent',
+    interactive: true,
+    trigger: 'mouseenter focus',
+    aria: {
+      content: 'describedby',
+    },
   });
 
   const thresholdLabel = this.settingZone.threshold.querySelector('pre');
@@ -162,6 +167,11 @@ Assistant.prototype.__refreshUI = async function() {
     placement: 'left',
     delay: 300,
     theme: 'translucent',
+    interactive: true,
+    trigger: 'mouseenter focus',
+    aria: {
+      content: 'describedby',
+    },
   });
 
   const overlapLabel = this.settingZone.overlap.querySelector('pre');
@@ -171,6 +181,11 @@ Assistant.prototype.__refreshUI = async function() {
     placement: 'left',
     delay: 300,
     theme: 'translucent',
+    interactive: true,
+    trigger: 'mouseenter focus',
+    aria: {
+      content: 'describedby',
+    },
   });
   this.modelPredictImgContainer = this.view.querySelector('.model-predict-image-container'),
 


### PR DESCRIPTION
### Fixes #994

#### Explanation of Changes

- **`interactive: true`**: Keeps the tooltip open when hovering over the tooltip itself, so it doesn't disappear immediately. This fixes the issue where the tooltip would disappear before users can interact with it.
- **`trigger: 'mouseenter focus'`**: Ensures the tooltip activates on both mouse hover and keyboard focus, making it accessible for keyboard users and screen readers.
- **`aria` configuration**: Setting `aria: { content: 'describedby' }` links the tooltip to the label for screen readers, providing a description of the label's purpose.

This configuration help ensure tooltip remains visible when needed and is fully accessible for all users, including those who rely on screen readers.
