### PR TITLE
[FIX]: Add visual focus indicator to 'Upload from URL' and 'Upload from local' links (#1018)

### DIFF
--- a/apps/table.html
+++ b/apps/table.html
@@ -236,10 +236,11 @@
                                                 <div class="spinner-grow text-primary" role="status" style="margin-left: 1.2em;">
                                                     <span class="sr-only"></span>
                                                 </div> </div>
-                                                <a title="Upload from google drive" href="#" id='gdriveUpload' onclick="googlePickerStart()"><i style="font-size: 1.2em;" class="fab fa-google-drive"></i></a>
-                                                <a href="#" id='urlswitch' onclick="$('#urlInput').val(''); switchToUrl();" > <span style="position: absolute; right:2em;" > <i class="fas fa-link"></i> Upload from URL</span></a>
-                                                <a href="#" style="display: none;" id="fileswitch" onclick=" switchToFile();" > <span style="position: absolute; right:2em;" > <i class="fas fa-folder"></i> Upload from local</span></a>
-
+                                                <div style="display: flex; align-items: center; justify-content: space-between; flex-direction: row; margin: auto;">
+                                                    <a title="Upload from google drive" href="#" id='gdriveUpload' onclick="googlePickerStart()"><i style="font-size: 1.2em;" class="fab fa-google-drive"></i></a>
+                                                    <a href="#" style="text-decoration: none;" id='urlswitch' onclick="$('#urlInput').val(''); switchToUrl();" > <span style="right:2em;" > <i class="fas fa-link"></i> Upload from URL</span></a>
+                                                    <a href="#" style="display: none; text-decoration: none;" id="fileswitch" onclick=" switchToFile();" > <span style="right:2em;" > <i class="fas fa-folder"></i> Upload from local</span></a>
+                                                </div>
                                             </td>
                                         </tr>
                                         <tr id="filenameRow">


### PR DESCRIPTION
### Fixes #1018

#### Changes:

- **Layout Fix**: Wrapped the Google Drive, "Upload from URL", and "Upload from Local" links in a flexbox (`display: flex; align-items: center; justify-content: space-between;`) and removed the absolute positioning to resolve the issue.
  
#### Final Result:
![Screenshot 2024-11-15 210705](https://github.com/user-attachments/assets/f309a222-3723-4fe8-bebe-7a6867cf5ae2)




