### PR TITLE
Create stale_issues.yml

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,17 @@
+name: 'Stale Issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-stale: 30
+          days-before-close: 5
+          days-before-pr-close: -1


### PR DESCRIPTION
A lot of issues are old. While I'm going through them now, I'm adding this workflow to hopefully keep things from staying too still.
It should:
- comment on PRs and Issues
- close Issues

This is overridden by commenting on an issue.