### PR TITLE
Adjusted the menu bar in home,info and signup tabs

### DIFF
--- a/apps/Info.html
+++ b/apps/Info.html
@@ -64,7 +64,7 @@
 	<div>
 		<nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
 			<div class="container-fluid">
-				<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" style="width: 100%;">
+				<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-icon"></span>
 					</button>
 					<div class="collapse navbar-collapse" id="navbarSupportedContent" >

--- a/apps/landing/landing.html
+++ b/apps/landing/landing.html
@@ -45,7 +45,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
     <div class="container-fluid">
-        <button class="navbar-toggler m-1" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" style="width: 100%;">
+        <button class="navbar-toggler m-1" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
             </button>
             <div class="collapse navbar-collapse" id="navbarSupportedContent" >

--- a/apps/signup/signup.html
+++ b/apps/signup/signup.html
@@ -37,7 +37,7 @@
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" style="position: sticky; margin-top: -4em;">
       <div class="container-fluid">
-          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation" style="width: 100%;">
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
               <span class="navbar-toggler-icon"></span>
               </button>
               <div class="collapse navbar-collapse" id="navbarSupportedContent" >


### PR DESCRIPTION
Issue #1057 
This PR addresses the alignment issues of the menu button in the Info, Home, and Signup tabs. The adjustments enhance the overall UI consistency and improve user experience

## Summary
Adjusted the menu button positioning across the following tabs in mobile version:
Info Tab
Home Tab
Signup Tab

## Testing
Verified changes in local development environment.
Tested across multiple browsers (Chrome, Firefox, Edge) to ensure compatibility.

## Screenshots
1) Home-
![image](https://github.com/user-attachments/assets/9ae1240e-709c-4b2f-ab09-449195d067dd)

2) Info-
![image](https://github.com/user-attachments/assets/cab0c47d-4656-4978-af4d-4e08e7316c2d)

3) Sign up-
![image](https://github.com/user-attachments/assets/90c2f983-47b2-4b62-aebd-87cc88a2c888)



I’d love to hear your feedback on this update or suggestions for further refinement


