### PR TITLE
Fixes:  Footer Not Present on info page Issue

### DIFF
--- a/apps/Info.html
+++ b/apps/Info.html
@@ -152,29 +152,27 @@
 </div>
 </div>
 
-
 <!-- footer -->
 <footer id="footer-layout"></footer>
 </div>
-
-
-    <!-- script to call a footer(layout footer in the common > utils folder) function -->
-<script> insertFooterLayout(); </script>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-p34f1UUtsS3wqzfto5wAAmdvj+osOnFyQFpp4Ua3gs/ZVWx6oOypYoCJhGGScy+8" crossorigin="anonymous"></script>
 
 <script src='../common/authChecker.js'></script>
 
 <script>
-		__auth_check(1)
-</script>
-
-<script src='../core/Store.js'></script>
-<script src='../common/util.js'></script>
-<script src='../common/ajv.js'></script>
-<script src='../components/loading/loading.js'></script>
-<script src="./loader/loader.js"></script>
-<script src="./loader/chunked_upload.js"></script>
+	__auth_check(1)
+	</script>
+	
+	<script src='../core/Store.js'></script>
+	<script src='../common/util.js'></script>
+	<script src='../common/ajv.js'></script>
+	<script src='../components/loading/loading.js'></script>
+	<script src="./loader/loader.js"></script>
+	<script src="./loader/chunked_upload.js"></script>
+	
+	<!-- script to call a footer(layout footer in the common > utils folder) function -->
+	<script> insertFooterLayout(); </script>
 </body>
 <script>
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title -->
Fixes #1061 by @ishaanxgupta 
Fix footer rendering issue by relocating the `insertFooterLayout()` script.

## Summary
<!--- Describe the changes in more detail. Feel free to include screenshots if relevant. -->
The `insertFooterLayout()` script was initially placed just below the `id="footer-layout"` element, causing the function to fail as the DOM was not fully loaded. The script was relocated to the end of the `body` tag, ensuring the DOM is fully loaded before executing the function.
### Before Fix
* The footer content was not rendered correctly when the script was placed immediately after the `footer-layout` element.
### After Fix
* The footer content now renders as expected since the script executes after the entire DOM is loaded.

## Motivation
<!--- Why have you made this Pull Request? Does this fix an open issue? -->
This pull request addresses an issue with the footer not being correctly inserted into the footer-layout element due to the script running prematurely. Moving the script ensures reliable and consistent footer rendering on info page.

## Testing
<!--- Has this been tested beyond the automatic hooks? How so? -->
![Screenshot 2025-01-09 220202](https://github.com/user-attachments/assets/21980bf3-69df-443e-ad0e-639dd218212d)
![Screenshot (848)](https://github.com/user-attachments/assets/ffec718d-0b81-49ca-badc-b399623e2aa9)
* Manually tested the fix on info page in the application to confirm that the footer renders correctly in all cases.
* Verified that other scripts and components were unaffected by this change.
* Ensured the change follows best practices for script placement to avoid potential future issues.

<!--- Mark a pull request as a draft to signal that it is not ready for review. -->
